### PR TITLE
Bugfix: Remove pip symlink from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@ RUN \
 RUN \
     apt-get update \
     && apt-get install -y python3.8 python3-pip \
-    && ln -s /usr/bin/python3.8 /usr/bin/python \
-    && ln -s /usr/bin/pip3 /usr/bin/pip
+    && ln -s /usr/bin/python3.8 /usr/bin/python
 
 # Install lib required for psycopg2
 RUN \


### PR DESCRIPTION
When cloning the repo and running `python build.py --make`,
the creation of the symlink to /usr/bin/pip3 fails because /usr/bin/pip already exists:
```
ln: failed to create symbolic link '/usr/bin/pip': File exists
```
It looks like the /usr/bin/pip executable is already added by the python3-pip 
package so the symlink is no longer required and has been removed in this PR.

