### PR TITLE
Bugfix: Add each new user to the global extension project

### DIFF
--- a/backend/src/contaxy/api/endpoints/auth.py
+++ b/backend/src/contaxy/api/endpoints/auth.py
@@ -428,7 +428,7 @@ def login_callback(
     )
 
     if user:
-        auth_utils.create_user_project(user, component_manager.get_project_manager())
+        auth_utils.setup_user(user, component_manager.get_project_manager())
 
     # ! Currently, the webapp needs to be accessible via the same host/port
     response = RedirectResponse(

--- a/backend/src/contaxy/api/endpoints/user.py
+++ b/backend/src/contaxy/api/endpoints/user.py
@@ -74,7 +74,7 @@ def create_user(
         user_input, technical_user=False
     )
 
-    auth_utils.create_user_project(user, component_manager.get_project_manager())
+    auth_utils.setup_user(user, component_manager.get_project_manager())
 
     # TODO: return also user_project?
     return user

--- a/backend/src/contaxy/managers/seed.py
+++ b/backend/src/contaxy/managers/seed.py
@@ -9,7 +9,7 @@ from contaxy.operations import AuthOperations, FileOperations, ProjectOperations
 from contaxy.operations.seed import SeedOperations
 from contaxy.schema import File, Project, User, UserRegistration
 from contaxy.schema.project import ProjectCreation
-from contaxy.utils.auth_utils import create_user_project
+from contaxy.utils.auth_utils import setup_user
 from contaxy.utils.file_utils import FileStreamWrapper
 from contaxy.utils.state_utils import GlobalState, RequestState
 
@@ -43,7 +43,7 @@ class SeedManager(SeedOperations):
         if not self.auth_manager:
             raise RuntimeError("Seeder needs to be initialized with an auth manager")
         user = self.auth_manager.create_user(user_input=user_input)
-        self.create_user_project(user)
+        self.setup_user(user)
         return user
 
     def create_users(self, amount: int) -> List[User]:
@@ -60,10 +60,10 @@ class SeedManager(SeedOperations):
 
         return users
 
-    def create_user_project(self, user: User) -> Project:
+    def setup_user(self, user: User) -> Project:
         if not self.project_manager:
             raise RuntimeError(ERROR_NO_PROJECT_MANAGER)
-        return create_user_project(user, self.project_manager)
+        return setup_user(user, self.project_manager)
 
     def create_project(
         self,

--- a/backend/src/contaxy/managers/system.py
+++ b/backend/src/contaxy/managers/system.py
@@ -102,4 +102,4 @@ class SystemManager(SystemOperations):
             technical_project=True,
         )
 
-        auth_utils.create_user_project(admin_user, self._project_manager)
+        auth_utils.setup_user(admin_user, self._project_manager)

--- a/backend/src/contaxy/utils/auth_utils.py
+++ b/backend/src/contaxy/utils/auth_utils.py
@@ -5,6 +5,7 @@ from contaxy.operations.project import ProjectOperations
 from contaxy.schema import Project, User
 from contaxy.schema.auth import AccessLevel
 from contaxy.schema.exceptions import ClientValueError
+from contaxy.schema.extension import GLOBAL_EXTENSION_PROJECT
 from contaxy.schema.project import ProjectCreation
 
 PERMISSION_SEPERATOR = "#"
@@ -116,8 +117,12 @@ def is_permission_granted(granted_permission: str, requested_permission: str) ->
     return True
 
 
-def create_user_project(user: User, project_manager: ProjectOperations) -> Project:
-    """Create a technical project that belongs to the user, with the same id as the user.
+def setup_user(user: User, project_manager: ProjectOperations) -> Project:
+    """Execute initial setup required for each new user.
+
+    This includes:
+    - Creation of a technical project that belongs to the user, with the same id as the user id.
+    - Addition of the new user to the global extension project so the user can access global extensions.
 
     Args:
         user (User): The user for whom the project shall be created.
@@ -140,6 +145,11 @@ def create_user_project(user: User, project_manager: ProjectOperations) -> Proje
 
     if user_project.id:
         project_manager.add_project_member(user_project.id, user.id, AccessLevel.ADMIN)
+
+    # User requires read access to the global extension project to access the extension endpoints
+    project_manager.add_project_member(
+        GLOBAL_EXTENSION_PROJECT, user.id, AccessLevel.READ
+    )
 
     return user_project
 


### PR DESCRIPTION
Extensions that should be available for all users are installed into the 
global extension project. All users need read access to this project so
they can access the extension services running there.

The code for adding a new user to the global extension project was added 
at the end of the `create_user_project` function because it is already 
called for each new user. It was renamed to `setup_user` because it now 
not only creates the user project.

Maybe instead this `setup_user` function could also be removed entirely 
and the user permission setup is instead done directly in the `create_user`
function. That would also prevent the accidental creation of a user without
calling the `setup_user` function. I could update this PR if that would
be the preferred solution.
