### PR TITLE
Extract project id from service metadata in map_service_to_extension

### DIFF
--- a/backend/src/contaxy/managers/extension.py
+++ b/backend/src/contaxy/managers/extension.py
@@ -51,9 +51,7 @@ def parse_composite_id(composite_id: str) -> Tuple[str, Union[str, None]]:
     return resource_id, extension_id
 
 
-def map_service_to_extension(
-    service: Service, user_id: str
-) -> Extension:
+def map_service_to_extension(service: Service, user_id: str) -> Extension:
     extension = Extension(**service.dict())
 
     if service.metadata:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -18,8 +18,8 @@ class TestSettings(BaseSettings):
     ACTIVATE_TEST_PROFILING: bool = True
     POSTGRES_INTEGRATION_TESTS: bool = False
     MINIO_INTEGRATION_TESTS: bool = False
-    REMOTE_BACKEND_TESTS: bool = False
-    REMOTE_BACKEND_ENDPOINT: Optional[str] = None
+    REMOTE_BACKEND_TESTS: bool = True
+    REMOTE_BACKEND_ENDPOINT: Optional[str] = "http://localhost:8082"
     DOCKER_INTEGRATION_TESTS: bool = True
     KUBERNETES_INTEGRATION_TESTS: bool = False
 


### PR DESCRIPTION
The project id does not need to be passed to the `map_service_to_extension`
function because it can be retrieved from the service metadata. This fixes a
bug in `list_extensions` where the wrong `project_id` is passed for global
extensions.
