### PR TITLE
Connect backend to all docker networks of the installation on start up.

### DIFF
--- a/backend/src/contaxy/managers/deployment/docker.py
+++ b/backend/src/contaxy/managers/deployment/docker.py
@@ -14,6 +14,7 @@ from contaxy.managers.deployment.docker_utils import (
     map_job,
     map_service,
     read_container_logs,
+    reconnect_to_all_networks,
 )
 from contaxy.managers.deployment.manager import DeploymentManager
 from contaxy.managers.deployment.utils import Labels
@@ -25,6 +26,8 @@ from contaxy.utils.state_utils import GlobalState, RequestState
 
 
 class DockerDeploymentManager(DeploymentManager):
+    _is_initialized = False
+
     def __init__(
         self,
         global_state: GlobalState,
@@ -40,6 +43,10 @@ class DockerDeploymentManager(DeploymentManager):
         self.request_state = request_state
 
         self.client = docker.from_env()
+        # Reconnect the backend to all existing docker networks on startup
+        if not DockerDeploymentManager._is_initialized:
+            reconnect_to_all_networks(self.client)
+            DockerDeploymentManager._is_initialized = True
 
     def list_services(
         self,


### PR DESCRIPTION
For each service that is started, a dedicated docker network is created. It includes only the backend and service container.
That way the service is isolated on a network level and can only communicate with the backend. After the backend container is recreated (e.g. updating the image), it is no longer part of the networks. This PR checks all networks on first creation of the DockerDeploymentManager and adds the backend back to the networks that belong to the installation.

One issue with this implementation:
The reconnection to the networks happens the first time the DockerDeploymentManager is created. As it is created lazily on demand, this would happen after the first service related request. This first request could therefore take more time. To prevent this, the service manager could be created once on server startup to ensure the network reconnection happens.


