### PR TITLE
Ensure /system/initialize endpoint is not called more than once

### DIFF
--- a/backend/src/contaxy/api/endpoints/system.py
+++ b/backend/src/contaxy/api/endpoints/system.py
@@ -88,7 +88,6 @@ def initialize_system(
     component_manager: ComponentManager = Depends(get_component_manager),
 ) -> Any:
     """Initializes the system."""
-    # TODO: only allow this to be called once
     component_manager.get_system_manager().initialize_system()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 

--- a/backend/src/contaxy/managers/system.py
+++ b/backend/src/contaxy/managers/system.py
@@ -8,8 +8,8 @@ from contaxy.operations.json_db import JsonDocumentOperations
 from contaxy.operations.project import ProjectOperations
 from contaxy.schema import (
     ClientValueError,
-    ResourceNotFoundError,
     ResourceAlreadyExistsError,
+    ResourceNotFoundError,
 )
 from contaxy.schema.auth import ADMIN_ROLE, USERS_KIND, AccessLevel, UserRegistration
 from contaxy.schema.project import ProjectCreation
@@ -66,6 +66,7 @@ class SystemManager(SystemOperations):
         password: Optional[str] = None,
     ) -> None:
         # Don't execute initialization if there are already existing users
+        # TODO: This does not prevent the usage of the contaxy API before the system is initialized
         if len(self._auth_manager.list_users()) > 0:
             raise ResourceAlreadyExistsError("The system has already been initialized")
 

--- a/backend/src/contaxy/managers/system.py
+++ b/backend/src/contaxy/managers/system.py
@@ -6,7 +6,11 @@ from contaxy.managers.auth import AuthManager
 from contaxy.operations import SystemOperations
 from contaxy.operations.json_db import JsonDocumentOperations
 from contaxy.operations.project import ProjectOperations
-from contaxy.schema import ClientValueError, ResourceNotFoundError
+from contaxy.schema import (
+    ClientValueError,
+    ResourceNotFoundError,
+    ResourceAlreadyExistsError,
+)
 from contaxy.schema.auth import ADMIN_ROLE, USERS_KIND, AccessLevel, UserRegistration
 from contaxy.schema.project import ProjectCreation
 from contaxy.schema.system import AllowedImageInfo, SystemInfo, SystemStatistics
@@ -61,6 +65,10 @@ class SystemManager(SystemOperations):
         self,
         password: Optional[str] = None,
     ) -> None:
+        # Don't execute initialization if there are already existing users
+        if len(self._auth_manager.list_users()) > 0:
+            raise ResourceAlreadyExistsError("The system has already been initialized")
+
         # Remove authorized access info
         self._request_state.authorized_access = None
 


### PR DESCRIPTION
Currently, the /system/initialize endpoint can be called multiple times without authentication. This allows anyone to reset the instance and create an admin account. 
This simple fix checks if there are already users in the DB. If that is the case, the system is not initialized again. This is not perfect, as it does not prevent the usage of the system before initialization is done. Maybe at some point, we could discuss the general idea of this initialization endpoint again.