### PR TITLE
Allow usage of default environment variables in service/job template mappings.

### DIFF
--- a/backend/src/contaxy/managers/deployment/docker_utils.py
+++ b/backend/src/contaxy/managers/deployment/docker_utils.py
@@ -9,7 +9,6 @@ from loguru import logger
 
 from contaxy.config import settings
 from contaxy.managers.deployment.utils import (
-    _ENV_VARIABLE_CONTAXY_SERVICE_URL,
     _MIN_MEMORY_DEFAULT_MB,
     DEFAULT_DEPLOYMENT_ACTION_ID,
     NO_LOGS_MESSAGE,
@@ -510,9 +509,7 @@ def create_container_config(
     environment = replace_templates(
         environment,
         get_template_mapping(
-            project_id=project_id,
-            user_id=user_id,
-            service_url=environment.get(_ENV_VARIABLE_CONTAXY_SERVICE_URL, ""),
+            project_id=project_id, user_id=user_id, environment=environment
         ),
     )
 

--- a/backend/src/contaxy/managers/deployment/kube_utils.py
+++ b/backend/src/contaxy/managers/deployment/kube_utils.py
@@ -34,7 +34,6 @@ from kubernetes.client.rest import ApiException
 
 from contaxy.config import settings
 from contaxy.managers.deployment.utils import (
-    _ENV_VARIABLE_CONTAXY_SERVICE_URL,
     _MIN_MEMORY_DEFAULT_MB,
     Labels,
     clean_labels,
@@ -250,9 +249,7 @@ def build_pod_template_spec(
     environment = replace_templates(
         environment,
         get_template_mapping(
-            project_id=project_id,
-            user_id=user_id,
-            service_url=environment.get(_ENV_VARIABLE_CONTAXY_SERVICE_URL, ""),
+            project_id=project_id, user_id=user_id, environment=environment
         ),
     )
 

--- a/backend/src/contaxy/managers/deployment/utils.py
+++ b/backend/src/contaxy/managers/deployment/utils.py
@@ -20,6 +20,7 @@ _MIN_MEMORY_DEFAULT_MB = 100
 _ENV_VARIABLE_CONTAXY_BASE_URL = "CONTAXY_BASE_URL"
 _ENV_VARIABLE_CONTAXY_API_ENDPOINT = "CONTAXY_API_ENDPOINT"
 _ENV_VARIABLE_CONTAXY_SERVICE_URL = "CONTAXY_SERVICE_URL"
+_ENV_VARIABLE_CONTAXY_DEPLOYMENT_NAME = "CONTAXY_DEPLOYMENT_NAME"
 
 
 class Labels(Enum):
@@ -244,7 +245,7 @@ def get_default_environment_variables(
     """
 
     default_environment_variables = {
-        "CONTAXY_DEPLOYMENT_NAME": deployment_id,
+        _ENV_VARIABLE_CONTAXY_DEPLOYMENT_NAME: deployment_id,
         _ENV_VARIABLE_CONTAXY_BASE_URL: settings.CONTAXY_BASE_URL,
         _ENV_VARIABLE_CONTAXY_API_ENDPOINT: settings.CONTAXY_API_ENDPOINT,
     }
@@ -253,6 +254,7 @@ def get_default_environment_variables(
         endpoint = endpoints[0]
         if len(endpoints) > 1:
             endpoint = "{endpoint}"
+        # TODO: This url is only valid for services but not for jobs
         default_environment_variables[
             _ENV_VARIABLE_CONTAXY_SERVICE_URL
         ] = f"{settings.CONTAXY_BASE_URL}/projects/{project_id}/services/{deployment_id}/access/{endpoint}"
@@ -324,7 +326,7 @@ def replace_templates(
 def get_template_mapping(
     project_id: Optional[str] = None,
     user_id: Optional[str] = None,
-    service_url: Optional[str] = None,
+    environment: Dict[str, str] = None,
 ) -> Dict[str, str]:
     template_mapping = {}
 
@@ -344,8 +346,9 @@ def get_template_mapping(
     if user_id:
         template_mapping["{env.userId}"] = user_id
 
-    if service_url:
-        template_mapping[f"{{env.{_ENV_VARIABLE_CONTAXY_SERVICE_URL}}}"] = service_url
+    if environment:
+        for env_name, env_value in environment.items():
+            template_mapping[f"{{env.{env_name}}}"] = env_value
 
     return template_mapping
 


### PR DESCRIPTION
There are some environment variables that are automatically set for a new service. For example the `CONTAXY_DEPLOYMENT_NAME` environment variable which contains the name of the docker container/pod of the service. However, sometimes these values need to be set with a different variable name because the service image can not be adjusted.
An example is the [ml-workspace](https://github.com/ml-tooling/ml-workspace) image. It requires the `SSH_JUMPHOST_TARGET` variable to be set to the hostname of the service. This is exactly the value of the `CONTAXY_DEPLOYMENT_NAME `variable. With the changes in this PR, it is possible to use any default environment variable in the service template syntax:
```
workspace_service_config = ServiceInput(
    container_image="mltooling/ml-workspace",
    parameters={
        "SSH_JUMPHOST_TARGET": "{env.CONTAXY_DEPLOYMENT_NAME}",
    },
```
This way the workspace image does not need to be modified.