### PR TITLE
Add API Token to each service/job which allows access to itself

### DIFF
--- a/backend/src/contaxy/managers/components.py
+++ b/backend/src/contaxy/managers/components.py
@@ -241,7 +241,10 @@ class ComponentManager:
                 from contaxy.managers.deployment.docker import DockerDeploymentManager
 
                 self._deployment_manager = DockerDeploymentManager(
-                    self.global_state, self.request_state, self.get_system_manager()
+                    self.global_state,
+                    self.request_state,
+                    self.get_system_manager(),
+                    self.get_auth_manager(),
                 )
             elif (
                 self.global_state.settings.DEPLOYMENT_MANAGER
@@ -255,6 +258,7 @@ class ComponentManager:
                     self.global_state,
                     self.request_state,
                     self.get_system_manager(),
+                    self.get_auth_manager(),
                     self.global_state.settings.KUBERNETES_NAMESPACE,
                 )
 

--- a/backend/src/contaxy/managers/deployment/docker_utils.py
+++ b/backend/src/contaxy/managers/deployment/docker_utils.py
@@ -8,6 +8,7 @@ import psutil
 from loguru import logger
 
 from contaxy.config import settings
+from contaxy.managers.auth import AuthManager
 from contaxy.managers.deployment.utils import (
     _ENV_VARIABLE_CONTAXY_SERVICE_URL,
     _MIN_MEMORY_DEFAULT_MB,
@@ -450,6 +451,7 @@ def define_mounts(
 def create_container_config(
     service: Union[JobInput, ServiceInput],
     project_id: str,
+    auth_manager: AuthManager,
     user_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     if service.display_name is None:
@@ -503,6 +505,7 @@ def create_container_config(
         **get_default_environment_variables(
             project_id=project_id,
             deployment_id=container_name,
+            auth_manager=auth_manager,
             endpoints=service.endpoints,
             compute_resources=compute_resources,
         ),


### PR DESCRIPTION
Some service require a token that allows access to the service itself. For example, a [ML workspace](https://github.com/ml-tooling/ml-workspace) service needs this token to build the SSH setup command (the token has to be included in a curl call that downloads the setup script from the workspace).
This PR adds the environment variable CONTAXY_API_TOKEN to each service which includes a token that provides read access to this service. For this, the AuthManager needs to be passed down through several function calls. In the `get_default_environment_variables` function it is then used to generate the token. 

Note:
The user creating the service will be used as the token subject. I don't know if this can cause issue but I think the service itself cannot be a token subject at the moment?