### PR TITLE
Bugfix: Prefix of volume source is None when HOST_DATA_ROOT_PATH is not set

### DIFF
--- a/backend/src/contaxy/config.py
+++ b/backend/src/contaxy/config.py
@@ -51,8 +51,13 @@ class Settings(BaseSettings):
     DEPLOYMENT_MANAGER: DeploymentManager = DeploymentManager.DOCKER
     KUBERNETES_NAMESPACE: Optional[str] = None
     HOST_DATA_ROOT_PATH: Optional[str] = None
-    if HOST_DATA_ROOT_PATH is not None and not HOST_DATA_ROOT_PATH.endswith("/"):
-        HOST_DATA_ROOT_PATH = f"{HOST_DATA_ROOT_PATH}/"
+
+    # Ensure host data root path ends with a slash
+    @validator("HOST_DATA_ROOT_PATH")
+    def _validate_host_data_root_path(cls, host_data_root_path: str) -> str:
+        if host_data_root_path is None or host_data_root_path.endswith("/"):
+            return host_data_root_path
+        return f"{host_data_root_path}/"
 
     # Postgres Connection URI to use for JSON Document Manager
     # If `None`, a dedicated postgres instance will be started as a service (container).

--- a/backend/src/contaxy/managers/deployment/docker_utils.py
+++ b/backend/src/contaxy/managers/deployment/docker_utils.py
@@ -430,11 +430,16 @@ def define_mounts(
         compute_resources.volume_path is not None
         and compute_resources.volume_path != ""
     ):
-        mount_type = "bind" if settings.HOST_DATA_ROOT_PATH is not None else "volume"
+        if settings.HOST_DATA_ROOT_PATH is None:
+            mount_type = "volume"
+            prefix = ""
+        else:
+            mount_type = "bind"
+            prefix = settings.HOST_DATA_ROOT_PATH
         mounts.append(
             docker.types.Mount(
                 target=str(compute_resources.volume_path),
-                source=f"{settings.HOST_DATA_ROOT_PATH}{get_volume_name(project_id, container_name)}",
+                source=f"{prefix}{get_volume_name(project_id, container_name)}",
                 labels={
                     Labels.NAMESPACE.value: settings.SYSTEM_NAMESPACE,
                     Labels.PROJECT_NAME.value: project_id,


### PR DESCRIPTION
This PR fixes two issues:
When HOST_DATA_ROOT_PATH is not set it resulted in volume names with a leading `None` (e.g. `Nonemy-project-pylab-p-my-project-s-test-vol`). 

The validation of the HOST_DATA_ROOT_PATH parameter (must end with slash) was not actually performed as it was not put into a validator method.