### PR TITLE
Feature: Allow admins to create users even if self registration is disabled.

### DIFF
--- a/backend/src/contaxy/api/dependencies.py
+++ b/backend/src/contaxy/api/dependencies.py
@@ -1,4 +1,4 @@
-from typing import Generator
+from typing import Generator, Optional
 
 from fastapi import Request, Security
 from fastapi.security import OAuth2PasswordBearer
@@ -9,32 +9,44 @@ from contaxy.managers.components import ComponentManager
 from contaxy.schema.exceptions import UnauthenticatedError
 
 
-def get_api_token(
-    api_token_query: str = Security(
-        APIKeyQuery(name=config.API_TOKEN_NAME, auto_error=False)
-    ),
-    api_token_header: str = Security(
-        APIKeyHeader(name=config.API_TOKEN_NAME, auto_error=False)
-    ),
-    bearer_token: str = Security(
-        OAuth2PasswordBearer(tokenUrl="auth/oauth/token", auto_error=False)
-    ),
-    api_token_cookie: str = Security(
-        APIKeyCookie(name=config.API_TOKEN_NAME, auto_error=False)
-    ),
-) -> str:
-    # TODO: already check token validity here?
-    if api_token_query:
-        return api_token_query
-    elif api_token_header:
-        return api_token_header
-    elif bearer_token:
-        # TODO: move the bearer token under the cookie?
-        return bearer_token
-    elif api_token_cookie:
-        return api_token_cookie
-    else:
-        raise UnauthenticatedError("No API token was provided.")
+class APITokenExtractor:
+    def __init__(self, *, auto_error: bool = True):
+        self.auto_error = auto_error
+
+    async def __call__(
+        self,
+        api_token_query: str = Security(
+            APIKeyQuery(name=config.API_TOKEN_NAME, auto_error=False)
+        ),
+        api_token_header: str = Security(
+            APIKeyHeader(name=config.API_TOKEN_NAME, auto_error=False)
+        ),
+        bearer_token: str = Security(
+            OAuth2PasswordBearer(tokenUrl="auth/oauth/token", auto_error=False)
+        ),
+        api_token_cookie: str = Security(
+            APIKeyCookie(name=config.API_TOKEN_NAME, auto_error=False)
+        ),
+    ) -> Optional[str]:
+        # TODO: already check token validity here?
+        if api_token_query:
+            return api_token_query
+        elif api_token_header:
+            return api_token_header
+        elif bearer_token:
+            # TODO: move the bearer token under the cookie?
+            return bearer_token
+        elif api_token_cookie:
+            return api_token_cookie
+        else:
+            if self.auto_error:
+                raise UnauthenticatedError("No API token was provided.")
+            else:
+                return None
+
+
+get_api_token = APITokenExtractor(auto_error=True)
+get_optional_api_token = APITokenExtractor(auto_error=False)
 
 
 def get_component_manager(request: Request) -> Generator[ComponentManager, None, None]:

--- a/backend/src/contaxy/managers/auth.py
+++ b/backend/src/contaxy/managers/auth.py
@@ -787,11 +787,17 @@ class AuthManager(AuthOperations):
         if not token_payload.get("email_verified"):
             # ? Prevent
             logger.warning(f"The email {email} is not verified")
+        user = None
         try:
             user_id = self._get_user_id_by_login_id(email)
         except ResourceNotFoundError:
-            user = self.create_user(UserRegistration(email=email))
-            user_id = user.id
+            if config.settings.USER_REGISTRATION_ENABLED:
+                user = self.create_user(UserRegistration(email=email))
+                user_id = user.id
+            else:
+                raise PermissionDeniedError(
+                    f"No existing account for {email} found! Please contact an administrator."
+                )
 
         return self._generate_token(user_id), user
 


### PR DESCRIPTION
At the moment, even admins cannot create new users when the USER_REGISTRATION_ENABLED variable is set.
To fix this, the get_optional_api_token function is introduced, which tries to retrieve the auth token but does not fail if no token is passed. This can be used in the create_user endpoint to check if the user has admin permissions while still allowing to call the endpoint without any token.