### PR TITLE
Feature: Add terminating state to service life-cycle

### DIFF
--- a/backend/src/contaxy/managers/deployment/kube_utils.py
+++ b/backend/src/contaxy/managers/deployment/kube_utils.py
@@ -555,20 +555,23 @@ def map_deployment(deployment: Union[V1Deployment, V1Job]) -> Dict[str, Any]:
     )
 
     try:
-        # TODO: detect failed?
-        # TODO: return RUNNING when at least MIN_REPLICAS is fulfilled
-        # TODO: if no replica is started, return FAILED
-        # TODO: if READY_REPLICAS < MIN_REPLICAS => check exit code of POD
-        # TODO: set failed when creation_timestamp is high but still unavailable
-        successful = (
-            deployment.status.ready_replicas == deployment.status.replicas
-            if hasattr(deployment.status, "ready_replicas")
-            else deployment.status.succeeded
-        )
-        if successful:
-            status = DeploymentStatus.RUNNING.value
+        if deployment.metadata.deletion_timestamp is not None:
+            status = DeploymentStatus.TERMINATING.value
         else:
-            status = DeploymentStatus.PENDING.value
+            # TODO: detect failed?
+            # TODO: return RUNNING when at least MIN_REPLICAS is fulfilled
+            # TODO: if no replica is started, return FAILED
+            # TODO: if READY_REPLICAS < MIN_REPLICAS => check exit code of POD
+            # TODO: set failed when creation_timestamp is high but still unavailable
+            successful = (
+                deployment.status.ready_replicas == deployment.status.replicas
+                if hasattr(deployment.status, "ready_replicas")
+                else deployment.status.succeeded
+            )
+            if successful:
+                status = DeploymentStatus.RUNNING.value
+            else:
+                status = DeploymentStatus.PENDING.value
     except ValueError:
         status = DeploymentStatus.UNKNOWN.value
 

--- a/backend/src/contaxy/schema/deployment.py
+++ b/backend/src/contaxy/schema/deployment.py
@@ -38,6 +38,8 @@ class DeploymentStatus(str, Enum):
     SUCCEEDED = "succeeded"
     # Deployment was stopped with failure exit code (> 0).
     FAILED = "failed"
+    # Deployment was deleted and is now terminating the pods.
+    TERMINATING = "terminating"
     # Deployment state cannot be obtained.
     UNKNOWN = "unknown"
     # Deployment is paused (only on docker?)/


### PR DESCRIPTION
When a deployment on Kubernetes is deleted, it takes a while for all the pods to be terminated. This PR is adding the "terminating" state which is returned for an ML Lab Service if the deployment was deleted but the pods are still being deleted.