### PR TITLE
Store deployment metadata in json DB

### DIFF
--- a/backend/src/contaxy/managers/components.py
+++ b/backend/src/contaxy/managers/components.py
@@ -6,6 +6,7 @@ from pydantic.networks import PostgresDsn
 
 from contaxy import config
 from contaxy.managers.auth import AuthManager
+from contaxy.managers.deployment.manager import DeploymentManagerWithDB
 from contaxy.managers.extension import ExtensionManager
 from contaxy.managers.project import ProjectManager
 from contaxy.managers.seed import SeedManager
@@ -246,6 +247,10 @@ class ComponentManager:
                     self.get_system_manager(),
                     self.get_auth_manager(),
                 )
+                # Add DB persistence to docker deployment manager
+                self._deployment_manager = DeploymentManagerWithDB(
+                    self._deployment_manager, self.get_json_db_manager()
+                )
             elif (
                 self.global_state.settings.DEPLOYMENT_MANAGER
                 == config.DeploymentManager.KUBERNETES
@@ -260,6 +265,10 @@ class ComponentManager:
                     self.get_system_manager(),
                     self.get_auth_manager(),
                     self.global_state.settings.KUBERNETES_NAMESPACE,
+                )
+                # Add DB persistence to kubernetes deployment manager
+                self._deployment_manager = DeploymentManagerWithDB(
+                    self._deployment_manager, self.get_json_db_manager()
                 )
 
         assert self._deployment_manager is not None

--- a/backend/src/contaxy/managers/deployment/docker.py
+++ b/backend/src/contaxy/managers/deployment/docker.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Literal, Optional
+from typing import Any, List, Literal, Optional
 
 import docker
 from loguru import logger
@@ -17,9 +17,9 @@ from contaxy.managers.deployment.docker_utils import (
     read_container_logs,
     reconnect_to_all_networks,
 )
-from contaxy.managers.deployment.manager import DeploymentManager
 from contaxy.managers.deployment.utils import Labels, split_image_name_and_tag
 from contaxy.managers.system import SystemManager
+from contaxy.operations import DeploymentOperations
 from contaxy.schema import Job, JobInput, ResourceAction, Service, ServiceInput
 from contaxy.schema.deployment import DeploymentType
 from contaxy.schema.exceptions import ClientBaseError, ClientValueError
@@ -27,7 +27,7 @@ from contaxy.utils.auth_utils import parse_userid_from_resource_name
 from contaxy.utils.state_utils import GlobalState, RequestState
 
 
-class DockerDeploymentManager(DeploymentManager):
+class DockerDeploymentManager(DeploymentOperations):
     _is_initialized = False
 
     def __init__(
@@ -234,3 +234,27 @@ class DockerDeploymentManager(DeploymentManager):
         )
 
         return read_container_logs(container=container, lines=lines, since=since)
+
+    def suggest_service_config(
+        self, project_id: str, container_image: str
+    ) -> ServiceInput:
+        raise NotImplementedError()
+
+    def list_service_actions(
+        self, project_id: str, service_id: str
+    ) -> List[ResourceAction]:
+        raise NotImplementedError()
+
+    def execute_service_action(
+        self, project_id: str, service_id: str, action_id: str
+    ) -> Any:
+        raise NotImplementedError()
+
+    def suggest_job_config(self, project_id: str, container_image: str) -> JobInput:
+        raise NotImplementedError()
+
+    def list_job_actions(self, project_id: str, job_id: str) -> List[ResourceAction]:
+        raise NotImplementedError()
+
+    def execute_job_action(self, project_id: str, job_id: str, action_id: str) -> Any:
+        raise NotImplementedError()

--- a/backend/src/contaxy/managers/deployment/kubernetes.py
+++ b/backend/src/contaxy/managers/deployment/kubernetes.py
@@ -1,6 +1,6 @@
 import time
 from datetime import datetime, timezone
-from typing import List, Literal, Optional
+from typing import Any, List, Literal, Optional
 
 from kubernetes import client as kube_client
 from kubernetes import config as kube_config
@@ -36,7 +36,6 @@ from contaxy.managers.deployment.kube_utils import (
     wait_for_deployment,
     wait_for_job,
 )
-from contaxy.managers.deployment.manager import DeploymentManager
 from contaxy.managers.deployment.utils import (
     DEFAULT_DEPLOYMENT_ACTION_ID,
     NO_LOGS_MESSAGE,
@@ -45,6 +44,7 @@ from contaxy.managers.deployment.utils import (
     split_image_name_and_tag,
 )
 from contaxy.managers.system import SystemManager
+from contaxy.operations import DeploymentOperations
 from contaxy.schema import Job, JobInput, ResourceAction, Service, ServiceInput
 from contaxy.schema.deployment import DeploymentType
 from contaxy.schema.exceptions import (
@@ -57,7 +57,7 @@ from contaxy.utils.auth_utils import parse_userid_from_resource_name
 from contaxy.utils.state_utils import GlobalState, RequestState
 
 
-class KubernetesDeploymentManager(DeploymentManager):
+class KubernetesDeploymentManager(DeploymentOperations):
     def __init__(
         self,
         global_state: GlobalState,
@@ -602,3 +602,27 @@ class KubernetesDeploymentManager(DeploymentManager):
         return self.get_service_logs(
             project_id=project_id, service_id=job_id, lines=lines, since=since
         )
+
+    def suggest_service_config(
+        self, project_id: str, container_image: str
+    ) -> ServiceInput:
+        raise NotImplementedError()
+
+    def list_service_actions(
+        self, project_id: str, service_id: str
+    ) -> List[ResourceAction]:
+        raise NotImplementedError()
+
+    def execute_service_action(
+        self, project_id: str, service_id: str, action_id: str
+    ) -> Any:
+        raise NotImplementedError()
+
+    def suggest_job_config(self, project_id: str, container_image: str) -> JobInput:
+        raise NotImplementedError()
+
+    def list_job_actions(self, project_id: str, job_id: str) -> List[ResourceAction]:
+        raise NotImplementedError()
+
+    def execute_job_action(self, project_id: str, job_id: str, action_id: str) -> Any:
+        raise NotImplementedError()

--- a/backend/src/contaxy/managers/deployment/manager.py
+++ b/backend/src/contaxy/managers/deployment/manager.py
@@ -1,16 +1,261 @@
-from typing import List
+from datetime import datetime
+from typing import Dict, List, Literal, Optional
 
 from starlette.responses import Response
 
+from contaxy import config
 from contaxy.config import settings
-from contaxy.operations import DeploymentOperations
-from contaxy.schema import JobInput, ResourceAction, ServiceInput
+from contaxy.operations import DeploymentOperations, JsonDocumentOperations
+from contaxy.schema import (
+    Job,
+    JobInput,
+    ResourceAction,
+    ResourceNotFoundError,
+    Service,
+    ServiceInput,
+)
+from contaxy.schema.deployment import DeploymentStatus, DeploymentType
 
 ACTION_DELIMITER = "-"
 ACTION_ACCESS = "access"
 
 
-class DeploymentManager(DeploymentOperations):
+def _get_service_collection_id(project_id: str) -> str:
+    return f"project_{project_id}_service_metadata"
+
+
+def _get_job_collection_id(project_id: str) -> str:
+    return f"project_{project_id}_job_metadata"
+
+
+class DeploymentManagerWithDB(DeploymentOperations):
+    def __init__(
+        self,
+        deployment_manager: DeploymentOperations,
+        json_db_manager: JsonDocumentOperations,
+    ):
+        self.deployment_manager = deployment_manager
+        self.json_db = json_db_manager
+
+    def deploy_service(
+        self,
+        project_id: str,
+        service: ServiceInput,
+        action_id: Optional[str] = None,
+        deployment_type: Literal[
+            DeploymentType.SERVICE, DeploymentType.EXTENSION
+        ] = DeploymentType.SERVICE,
+    ) -> Service:
+        deployed_service = self.deployment_manager.deploy_service(
+            project_id, service, action_id, deployment_type
+        )
+        self.json_db.create_json_document(
+            project_id=config.SYSTEM_INTERNAL_PROJECT,
+            collection_id=_get_service_collection_id(project_id),
+            key=deployed_service.id,
+            json_document=deployed_service.json(),
+            upsert=False,
+        )
+        return deployed_service
+
+    def list_services(
+        self,
+        project_id: str,
+        deployment_type: Literal[
+            DeploymentType.SERVICE, DeploymentType.EXTENSION
+        ] = DeploymentType.SERVICE,
+    ) -> List[Service]:
+        service_docs = self.json_db.list_json_documents(
+            project_id=config.SYSTEM_INTERNAL_PROJECT,
+            collection_id=_get_service_collection_id(project_id),
+        )
+        deployed_service_lookup: Dict[str, Service] = {
+            service.id: service
+            for service in self.deployment_manager.list_services(
+                project_id, deployment_type
+            )
+            if service.id is not None
+        }
+        services = []
+        # Go through all services in the DB and update their status
+        for service_doc in service_docs:
+            db_service = Service.parse_raw(service_doc.json_value)
+            deployed_service = deployed_service_lookup.pop(db_service.id, None)
+            if deployed_service is None:
+                db_service.status = DeploymentStatus.STOPPED
+            else:
+                db_service.status = deployed_service.status
+            services.append(db_service)
+        # Add services to DB that were not added via the contaxy API
+        for deployed_service in deployed_service_lookup.values():
+            self.json_db.create_json_document(
+                project_id=config.SYSTEM_INTERNAL_PROJECT,
+                collection_id=_get_service_collection_id(project_id),
+                key=deployed_service.id,
+                json_document=deployed_service.json(),
+                upsert=False,
+            )
+            services.append(deployed_service)
+
+        return services
+
+    def get_service_metadata(self, project_id: str, service_id: str) -> Service:
+        db_service = self._get_service_from_db(project_id, service_id)
+        try:
+            deployed_service = self.deployment_manager.get_service_metadata(
+                project_id, db_service.id
+            )
+            db_service.status = deployed_service.status
+        except ResourceNotFoundError:
+            db_service.status = DeploymentStatus.STOPPED
+
+        return db_service
+
+    def delete_service(
+        self, project_id: str, service_id: str, delete_volumes: bool = False
+    ) -> None:
+        db_service = self._get_service_from_db(project_id, service_id)
+
+        try:
+            self.deployment_manager.delete_service(
+                project_id=project_id,
+                service_id=db_service.id,
+                delete_volumes=delete_volumes,
+            )
+        except ResourceNotFoundError:
+            # Workspace is already stopped and service does not exist
+            pass
+
+        self.json_db.delete_json_document(
+            project_id=config.SYSTEM_INTERNAL_PROJECT,
+            collection_id=_get_service_collection_id(project_id),
+            key=db_service.id,
+        )
+
+    def delete_services(self, project_id: str) -> None:
+        self.deployment_manager.delete_services(project_id)
+        self.json_db.delete_json_collection(
+            config.SYSTEM_INTERNAL_PROJECT, _get_service_collection_id(project_id)
+        )
+
+    def _get_service_from_db(self, project_id: str, service_id: str) -> Service:
+        try:
+            service_doc = self.json_db.get_json_document(
+                project_id=config.SYSTEM_INTERNAL_PROJECT,
+                collection_id=_get_service_collection_id(project_id),
+                key=service_id,
+            )
+        except ResourceNotFoundError:
+            raise ResourceNotFoundError(
+                f"The service with id {service_id} could not "
+                f"be found in project {project_id}!"
+            )
+        db_service = Service.parse_raw(service_doc.json_value)
+        return db_service
+
+    def get_service_logs(
+        self,
+        project_id: str,
+        service_id: str,
+        lines: Optional[int],
+        since: Optional[datetime],
+    ) -> str:
+        return self.deployment_manager.get_service_logs(
+            project_id, service_id, lines, since
+        )
+
+    def list_jobs(self, project_id: str) -> List[Job]:
+        job_docs = self.json_db.list_json_documents(
+            project_id=config.SYSTEM_INTERNAL_PROJECT,
+            collection_id=_get_job_collection_id(project_id),
+        )
+        deployed_job_lookup: Dict[Optional[str], Job] = {
+            job.id: job for job in self.deployment_manager.list_jobs(project_id)
+        }
+        jobs = []
+        for job_doc in job_docs:
+            db_job = Job.parse_raw(job_doc.json_value)
+            deployed_job = deployed_job_lookup.get(db_job.id)
+            if deployed_job is None:
+                db_job.status = DeploymentStatus.STOPPED
+            else:
+                db_job.status = deployed_job.status
+            jobs.append(db_job)
+
+        return jobs
+
+    def deploy_job(
+        self, project_id: str, job: JobInput, action_id: Optional[str] = None
+    ) -> Job:
+        deployed_job = self.deployment_manager.deploy_job(project_id, job, action_id)
+        self.json_db.create_json_document(
+            project_id=config.SYSTEM_INTERNAL_PROJECT,
+            collection_id=_get_job_collection_id(project_id),
+            key=deployed_job.id,
+            json_document=deployed_job.json(),
+            upsert=False,
+        )
+        return deployed_job
+
+    def get_job_metadata(self, project_id: str, job_id: str) -> Job:
+        db_job = self._get_job_from_db(project_id, job_id)
+        try:
+            deployed_job = self.deployment_manager.get_job_metadata(
+                project_id, db_job.id
+            )
+            db_job.status = deployed_job.status
+        except ResourceNotFoundError:
+            db_job.status = DeploymentStatus.STOPPED
+
+        return db_job
+
+    def delete_job(self, project_id: str, job_id: str) -> None:
+        db_job = self._get_job_from_db(project_id, job_id)
+
+        try:
+            self.deployment_manager.delete_job(
+                project_id=project_id,
+                job_id=db_job.id,
+            )
+        except ResourceNotFoundError:
+            pass
+
+        self.json_db.delete_json_document(
+            project_id=config.SYSTEM_INTERNAL_PROJECT,
+            collection_id=_get_job_collection_id(project_id),
+            key=db_job.id,
+        )
+
+    def delete_jobs(self, project_id: str) -> None:
+        self.deployment_manager.delete_jobs(project_id)
+        self.json_db.delete_json_collection(
+            config.SYSTEM_INTERNAL_PROJECT, _get_job_collection_id(project_id)
+        )
+
+    def _get_job_from_db(self, project_id: str, job_id: str) -> Job:
+        try:
+            job_doc = self.json_db.get_json_document(
+                project_id=config.SYSTEM_INTERNAL_PROJECT,
+                collection_id=_get_job_collection_id(project_id),
+                key=job_id,
+            )
+        except ResourceNotFoundError:
+            raise ResourceNotFoundError(
+                f"The job with id {job_id} could not "
+                f"be found in project {project_id}!"
+            )
+        db_job = Job.parse_raw(job_doc.json_value)
+        return db_job
+
+    def get_job_logs(
+        self,
+        project_id: str,
+        job_id: str,
+        lines: Optional[int] = None,
+        since: Optional[datetime] = None,
+    ) -> str:
+        return self.deployment_manager.get_job_logs(project_id, job_id, lines, since)
+
     def execute_service_action(
         self,
         project_id: str,
@@ -64,6 +309,16 @@ class DeploymentManager(DeploymentOperations):
                 )
 
         return resource_actions
+
+    def list_deploy_service_actions(
+        self, project_id: str, service: ServiceInput
+    ) -> List[ResourceAction]:
+        return self.deployment_manager.list_deploy_service_actions(project_id, service)
+
+    def list_deploy_job_actions(
+        self, project_id: str, job: JobInput
+    ) -> List[ResourceAction]:
+        return self.deployment_manager.list_deploy_job_actions(project_id, job)
 
     def list_job_actions(
         self,

--- a/backend/src/contaxy/managers/extension.py
+++ b/backend/src/contaxy/managers/extension.py
@@ -3,13 +3,12 @@ from typing import List, Optional, Tuple, Union
 from contaxy import config
 from contaxy.clients import DeploymentManagerClient, FileClient
 from contaxy.clients.shared import BaseUrlSession
-from contaxy.managers.deployment.manager import DeploymentManager
 from contaxy.managers.deployment.utils import (
     Labels,
     get_template_mapping,
     replace_template_string,
 )
-from contaxy.operations import ExtensionOperations
+from contaxy.operations import DeploymentOperations, ExtensionOperations
 from contaxy.schema import ExtensibleOperations, Extension, ExtensionInput, Service
 from contaxy.schema.deployment import DeploymentType, ServiceInput
 from contaxy.schema.extension import (
@@ -132,7 +131,7 @@ class ExtensionManager(ExtensionOperations):
         self,
         global_state: GlobalState,
         request_state: RequestState,
-        deployment_manager: DeploymentManager,
+        deployment_manager: DeploymentOperations,
     ):
         """Initializes the extension manager.
 

--- a/backend/src/contaxy/managers/json_db/postgres.py
+++ b/backend/src/contaxy/managers/json_db/postgres.py
@@ -316,6 +316,7 @@ class PostgresJsonDocumentManager(JsonDocumentOperations):
             conn.commit()
 
     def _add_metadata_for_insert(self, data: dict) -> dict:
+        # TODO: Copy required?
         insert_data = data.copy()
         # TODO: Finalize
         insert_data["created_at"] = datetime.datetime.utcnow()

--- a/backend/src/contaxy/schema/deployment.py
+++ b/backend/src/contaxy/schema/deployment.py
@@ -40,6 +40,8 @@ class DeploymentStatus(str, Enum):
     FAILED = "failed"
     # Deployment was deleted and is now terminating the pods.
     TERMINATING = "terminating"
+    # Deployment is stopped (it still exists in the DB but no container is running)
+    STOPPED = "stopped"
     # Deployment state cannot be obtained.
     UNKNOWN = "unknown"
     # Deployment is paused (only on docker?)/

--- a/backend/src/contaxy/schema/shared.py
+++ b/backend/src/contaxy/schema/shared.py
@@ -145,7 +145,7 @@ OPEN_URL_REDIRECT: Mapping[Union[int, str], Dict[str, Any]] = {
 
 
 class ResourceMetadata(BaseModel):
-    id: Optional[str] = Field(
+    id: str = Field(
         None,
         example="ac9ldprwdi68oihk34jli3kdp",
         description="Resource ID. Identifies a resource in a given context and time, for example, in combination with its type. Used in API operations and/or configuration files.",


### PR DESCRIPTION
At the moment metadata of deployments is only stored directly on the deployed containers/pods (as labels). As a result, this data will be lost once the container/pod is deleted. This PR stores the metadata of each deployment in the internal JSON DB so it is available even if the underlying container/pod was removed.
This provides some advantages:
- Services can be stopped (the underlying container/pod is removed but the deployment is still shown in the UI as stopped)
- Migrations can be easier as only the DB data needs to be transferred
- Features like updating the image of a service can be implemented without the risk of loosing data

This functionality is implemented in a wrapper class `DeploymentManagerWithDB` that builds on top of one of the existing deployment managers (Docker and Kubernetes). This replaces the old DeploymentManager which served as a base class for the Docker and Kubernetes managers.

Some implementation notes:
- The service metadata is not stored in the project the service is deployed to. Instead, a special collection for each project is created in the system project. That way, the owner of a project can not directly modify the metadata using the json db endpoints (which could lead to inconsistencies) and instead has to use the service API.
- A new status (STOPPED) has been added to deployments. It will be assigned when the underlying container/pod is missing and therefore the deployment can not be accessed (later start/stop/restart actions should be added)
- The list service function not only returns services in the DB but also returns services that were started externally and add them to the DB. This for example allows to start extensions externally in a docker compose file.
