### PR TITLE
Add functionality for updating, starting, stopping and restarting services

### DIFF
--- a/backend/src/contaxy/api/endpoints/deployment.py
+++ b/backend/src/contaxy/api/endpoints/deployment.py
@@ -175,6 +175,10 @@ def deploy_service(
         description="The action ID from the service deploy options.",
         regex=RESOURCE_ID_REGEX,
     ),
+    wait: bool = Query(
+        False,
+        description="If true, the server waits for the service to be ready before sending a response.",
+    ),
     component_manager: ComponentManager = Depends(get_component_manager),
     token: str = Depends(get_api_token),
 ) -> Any:
@@ -195,7 +199,7 @@ def deploy_service(
     if action_id:
         action_id, extension_id = parse_composite_id(action_id)
     return component_manager.get_service_manager(extension_id).deploy_service(
-        project_id, service, action_id
+        project_id, service, action_id, wait=wait
     )
 
 
@@ -526,6 +530,10 @@ def deploy_job(
         description="The action ID from the job deploy options.",
         regex=RESOURCE_ID_REGEX,
     ),
+    wait: bool = Query(
+        False,
+        description="If true, the server waits for the job to be ready before sending a response.",
+    ),
     component_manager: ComponentManager = Depends(get_component_manager),
     token: str = Depends(get_api_token),
 ) -> Any:
@@ -549,7 +557,7 @@ def deploy_job(
         action_id, extension_id = parse_composite_id(action_id)
 
     return component_manager.get_job_manager(extension_id).deploy_job(
-        project_id, job, action_id
+        project_id, job, action_id, wait=wait
     )
 
 

--- a/backend/src/contaxy/clients/deployment.py
+++ b/backend/src/contaxy/clients/deployment.py
@@ -7,7 +7,7 @@ from pydantic.tools import parse_raw_as
 from contaxy.clients.shared import handle_errors
 from contaxy.operations.deployment import DeploymentOperations
 from contaxy.schema import Job, JobInput, ResourceAction, Service, ServiceInput
-from contaxy.schema.deployment import DeploymentType
+from contaxy.schema.deployment import DeploymentType, ServiceUpdate
 
 
 class DeploymentManagerClient(DeploymentOperations):
@@ -54,6 +54,21 @@ class DeploymentManagerClient(DeploymentOperations):
         resource = self.client.post(
             f"/projects/{project_id}/services",
             params=params,
+            json=service.dict(exclude_unset=True),
+            **request_kwargs,
+        )
+        handle_errors(resource)
+        return parse_raw_as(Service, resource.text)
+
+    def update_service(
+        self,
+        project_id: str,
+        service_id: str,
+        service: ServiceUpdate,
+        request_kwargs: Dict = {},
+    ) -> Service:
+        resource = self.client.patch(
+            f"/projects/{project_id}/services/{service_id}",
             json=service.dict(exclude_unset=True),
             **request_kwargs,
         )

--- a/backend/src/contaxy/clients/deployment.py
+++ b/backend/src/contaxy/clients/deployment.py
@@ -40,9 +40,12 @@ class DeploymentManagerClient(DeploymentOperations):
         deployment_type: Literal[
             DeploymentType.SERVICE, DeploymentType.EXTENSION
         ] = DeploymentType.SERVICE,
+        wait: bool = False,
         request_kwargs: Dict = {},
     ) -> Service:
         params = {}
+        if wait:
+            params["wait"] = "true"
         if action_id:
             params["action_id"] = action_id
         if deployment_type == DeploymentType.EXTENSION:
@@ -197,9 +200,12 @@ class DeploymentManagerClient(DeploymentOperations):
         project_id: str,
         job: JobInput,
         action_id: Optional[str] = None,
+        wait: bool = False,
         request_kwargs: Dict = {},
     ) -> Job:
         params = {}
+        if wait:
+            params["wait"] = "true"
         if action_id:
             params["action_id"] = action_id
         resource = self.client.post(

--- a/backend/src/contaxy/managers/deployment/docker.py
+++ b/backend/src/contaxy/managers/deployment/docker.py
@@ -22,7 +22,7 @@ from contaxy.managers.deployment.utils import Labels, split_image_name_and_tag
 from contaxy.managers.system import SystemManager
 from contaxy.operations import DeploymentOperations
 from contaxy.schema import Job, JobInput, ResourceAction, Service, ServiceInput
-from contaxy.schema.deployment import DeploymentType
+from contaxy.schema.deployment import DeploymentType, ServiceUpdate
 from contaxy.schema.exceptions import ClientBaseError, ClientValueError
 from contaxy.utils.auth_utils import parse_userid_from_resource_name
 from contaxy.utils.state_utils import GlobalState, RequestState
@@ -120,6 +120,12 @@ class DockerDeploymentManager(DeploymentOperations):
             client=self.client, project_id=project_id, deployment_id=service_id
         )
         return map_service(container)
+
+    def update_service(
+        self, project_id: str, service_id: str, service: ServiceUpdate
+    ) -> Service:
+        # Service update is only implemented on DeploymentManagerWithDB wrapper
+        raise NotImplementedError()
 
     def delete_service(
         self, project_id: str, service_id: str, delete_volumes: bool = False

--- a/backend/src/contaxy/managers/deployment/docker_utils.py
+++ b/backend/src/contaxy/managers/deployment/docker_utils.py
@@ -106,7 +106,8 @@ def map_container(
 
     return {
         "container_image": container_image,
-        "command": " ".join(container.attrs.get("Args", [])),
+        "command": container.attrs["Config"].get("Entrypoint", []),
+        "args": container.attrs["Config"].get("Cmd", []),
         "compute": compute_resources,
         "metadata": mapped_labels.metadata,
         "deployment_type": mapped_labels.deployment_type,
@@ -535,7 +536,8 @@ def create_container_config(
     metadata = clean_labels(service.metadata)
     return {
         "image": service.container_image,
-        "command": service.command or None,
+        "entrypoint": service.command,
+        "command": service.args,
         "detach": True,
         "environment": environment,
         "labels": {

--- a/backend/src/contaxy/managers/deployment/docker_utils.py
+++ b/backend/src/contaxy/managers/deployment/docker_utils.py
@@ -1,5 +1,6 @@
 import ipaddress
 import os
+import time
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -573,6 +574,22 @@ def read_container_logs(
         logs = NO_LOGS_MESSAGE
 
     return logs
+
+
+def wait_for_container(
+    container: docker.models.containers.Container,
+    client: docker.client,
+    timeout: int = 60,
+) -> docker.models.containers.Container:
+    start = time.time()
+    while time.time() - start < timeout:
+        container_info = client.containers.get(container.id)
+        if container_info.status.lower() != "created":
+            return container_info
+        else:
+            time.sleep(2)
+
+    raise RuntimeError(f"Timeout while waiting for container {container.id}.")
 
 
 def list_deploy_service_actions(

--- a/backend/src/contaxy/managers/deployment/docker_utils.py
+++ b/backend/src/contaxy/managers/deployment/docker_utils.py
@@ -40,6 +40,7 @@ from contaxy.schema.deployment import (
 )
 from contaxy.schema.exceptions import (
     ClientBaseError,
+    ClientValueError,
     ResourceNotFoundError,
     ServerBaseError,
 )
@@ -320,7 +321,6 @@ def get_project_container(
     labels.append(
         get_label_string(Labels.DEPLOYMENT_NAME.value, deployment_id),
     )
-
     try:
         containers = client.containers.list(all=True, filters={"label": labels})
     except docker.errors.NotFound:
@@ -461,7 +461,7 @@ def create_container_config(
     user_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     if service.display_name is None:
-        raise RuntimeError("Service name not defined")
+        raise ClientValueError("Service display_name not defined")
 
     compute_resources = service.compute or DeploymentCompute()
     (

--- a/backend/src/contaxy/managers/deployment/kube_utils.py
+++ b/backend/src/contaxy/managers/deployment/kube_utils.py
@@ -1,4 +1,3 @@
-import shlex
 import string
 import time
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -262,8 +261,8 @@ def build_pod_template_spec(
         image=service.container_image,
         image_pull_policy="IfNotPresent",
         resources=resource_requirements,
-        # In Kubernetes, `command` must be an array and `shlex` helps to split the string like the shell would
-        command=shlex.split(service.command) if service.command else None,
+        command=service.command,
+        args=service.args,
         env=[V1EnvVar(name=name, value=value) for name, value in environment.items()],
         volume_mounts=[
             V1VolumeMount(
@@ -589,10 +588,8 @@ def map_deployment(deployment: Union[V1Deployment, V1Job]) -> Dict[str, Any]:
 
     return {
         "container_image": container.image,
-        # In kindkubernetes, command is an array
-        "command": container.command[0]
-        if container.command is not None and len(container.command) > 0
-        else "",
+        "command": container.command,
+        "args": container.args,
         "metadata": mapped_labels.metadata,
         "compute": compute_resources,
         "deployment_type": mapped_labels.deployment_type,

--- a/backend/src/contaxy/managers/deployment/kube_utils.py
+++ b/backend/src/contaxy/managers/deployment/kube_utils.py
@@ -603,7 +603,7 @@ def map_deployment(deployment: Union[V1Deployment, V1Job]) -> Dict[str, Any]:
         # "exit_code": container.attrs.get("State", {}).get("ExitCode", -1),
         "icon": mapped_labels.icon,
         "id": deployment.metadata.name,
-        "internal_id": deployment.metadata.name,
+        "internal_id": f"{deployment.metadata.name}-{deployment.metadata.uid}",
         "parameters": parameters,
         "started_at": started_at,
         "status": status,

--- a/backend/src/contaxy/managers/deployment/kubernetes.py
+++ b/backend/src/contaxy/managers/deployment/kubernetes.py
@@ -1,3 +1,4 @@
+import os
 import time
 from datetime import datetime, timezone
 from typing import Any, List, Literal, Optional
@@ -84,7 +85,7 @@ class KubernetesDeploymentManager(DeploymentOperations):
             # incluster config is the config given by a service account and it's role permissions
             kube_config.load_incluster_config()
         except kube_config.ConfigException:
-            kube_config.load_kube_config()
+            kube_config.load_kube_config(context=os.getenv("CTXY_K8S_CONTEXT", None))
 
         self.core_api = kube_client.CoreV1Api()
         self.apps_api = kube_client.AppsV1Api()

--- a/backend/src/contaxy/managers/deployment/kubernetes.py
+++ b/backend/src/contaxy/managers/deployment/kubernetes.py
@@ -46,7 +46,7 @@ from contaxy.managers.deployment.utils import (
 from contaxy.managers.system import SystemManager
 from contaxy.operations import DeploymentOperations
 from contaxy.schema import Job, JobInput, ResourceAction, Service, ServiceInput
-from contaxy.schema.deployment import DeploymentType
+from contaxy.schema.deployment import DeploymentType, ServiceUpdate
 from contaxy.schema.exceptions import (
     ClientBaseError,
     ClientValueError,
@@ -237,6 +237,12 @@ class KubernetesDeploymentManager(DeploymentOperations):
             )
 
         return transformed_service
+
+    def update_service(
+        self, project_id: str, service_id: str, service: ServiceUpdate
+    ) -> Service:
+        # Service update is only implemented on DeploymentManagerWithDB wrapper
+        raise NotImplementedError()
 
     def list_deploy_service_actions(
         self, project_id: str, service: ServiceInput

--- a/backend/src/contaxy/managers/deployment/manager.py
+++ b/backend/src/contaxy/managers/deployment/manager.py
@@ -1,3 +1,4 @@
+import time
 from datetime import datetime
 from typing import Dict, List, Literal, Optional
 
@@ -7,10 +8,12 @@ from contaxy import config
 from contaxy.config import settings
 from contaxy.operations import DeploymentOperations, JsonDocumentOperations
 from contaxy.schema import (
+    ClientValueError,
     Job,
     JobInput,
     ResourceAction,
     ResourceNotFoundError,
+    ServerBaseError,
     Service,
     ServiceInput,
 )
@@ -18,6 +21,9 @@ from contaxy.schema.deployment import DeploymentStatus, DeploymentType, ServiceU
 
 ACTION_DELIMITER = "-"
 ACTION_ACCESS = "access"
+ACTION_START = "start"
+ACTION_STOP = "stop"
+ACTION_RESTART = "restart"
 
 
 def _get_service_collection_id(project_id: str) -> str:
@@ -50,13 +56,7 @@ class DeploymentManagerWithDB(DeploymentOperations):
         deployed_service = self.deployment_manager.deploy_service(
             project_id, service, action_id, deployment_type, wait
         )
-        self.json_db.create_json_document(
-            project_id=config.SYSTEM_INTERNAL_PROJECT,
-            collection_id=_get_service_collection_id(project_id),
-            key=deployed_service.id,
-            json_document=deployed_service.json(),
-            upsert=False,
-        )
+        self._create_service_db_document(deployed_service, project_id)
         return deployed_service
 
     def list_services(
@@ -70,6 +70,7 @@ class DeploymentManagerWithDB(DeploymentOperations):
             project_id=config.SYSTEM_INTERNAL_PROJECT,
             collection_id=_get_service_collection_id(project_id),
         )
+        # Create lookup for all running services
         deployed_service_lookup: Dict[str, Service] = {
             service.id: service
             for service in self.deployment_manager.list_services(
@@ -78,27 +79,32 @@ class DeploymentManagerWithDB(DeploymentOperations):
             if service.id is not None
         }
         services = []
-        # Go through all services in the DB and update their status
+        # Go through all services in the DB and update their status and internal id
         for service_doc in service_docs:
             db_service = Service.parse_raw(service_doc.json_value)
             deployed_service = deployed_service_lookup.pop(db_service.id, None)
             if deployed_service is None:
                 db_service.status = DeploymentStatus.STOPPED
+                db_service.internal_id = None
             else:
                 db_service.status = deployed_service.status
+                db_service.internal_id = deployed_service.internal_id
             services.append(db_service)
         # Add services to DB that were not added via the contaxy API
         for deployed_service in deployed_service_lookup.values():
-            self.json_db.create_json_document(
-                project_id=config.SYSTEM_INTERNAL_PROJECT,
-                collection_id=_get_service_collection_id(project_id),
-                key=deployed_service.id,
-                json_document=deployed_service.json(),
-                upsert=False,
-            )
+            self._create_service_db_document(deployed_service, project_id)
             services.append(deployed_service)
 
         return services
+
+    def _create_service_db_document(self, service: Service, project_id: str) -> None:
+        self.json_db.create_json_document(
+            project_id=config.SYSTEM_INTERNAL_PROJECT,
+            collection_id=_get_service_collection_id(project_id),
+            key=service.id,
+            json_document=service.json(exclude={"status", "internal_id"}),
+            upsert=False,
+        )
 
     def get_service_metadata(self, project_id: str, service_id: str) -> Service:
         db_service = self._get_service_from_db(project_id, service_id)
@@ -107,8 +113,10 @@ class DeploymentManagerWithDB(DeploymentOperations):
                 project_id, db_service.id
             )
             db_service.status = deployed_service.status
+            db_service.internal_id = deployed_service.internal_id
         except ResourceNotFoundError:
             db_service.status = DeploymentStatus.STOPPED
+            db_service.internal_id = None
 
         return db_service
 
@@ -125,15 +133,14 @@ class DeploymentManagerWithDB(DeploymentOperations):
         )
         db_service = Service.parse_raw(service_doc.json_value)
         try:
-            self.deployment_manager.delete_service(
-                project_id, service_id, delete_volumes=False
-            )
-            deployed_service = self.deployment_manager.deploy_service(
-                project_id, ServiceInput(**db_service.dict())
+            deployed_service = self._execute_restart_service_action(
+                project_id, service_id
             )
             db_service.status = deployed_service.status
-        except ResourceNotFoundError:
+            db_service.internal_id = deployed_service.internal_id
+        except ClientValueError:
             db_service.status = DeploymentStatus.STOPPED
+            db_service.internal_id = None
 
         return db_service
 
@@ -204,8 +211,10 @@ class DeploymentManagerWithDB(DeploymentOperations):
             deployed_job = deployed_job_lookup.get(db_job.id)
             if deployed_job is None:
                 db_job.status = DeploymentStatus.STOPPED
+                db_job.internal_id = None
             else:
                 db_job.status = deployed_job.status
+                db_job.internal_id = deployed_job.internal_id
             jobs.append(db_job)
 
         return jobs
@@ -236,8 +245,10 @@ class DeploymentManagerWithDB(DeploymentOperations):
                 project_id, db_job.id
             )
             db_job.status = deployed_job.status
+            db_job.internal_id = deployed_job.internal_id
         except ResourceNotFoundError:
             db_job.status = DeploymentStatus.STOPPED
+            db_job.internal_id = None
 
         return db_job
 
@@ -294,21 +305,78 @@ class DeploymentManagerWithDB(DeploymentOperations):
         service_id: str,
         action_id: str,
     ) -> Response:
-        # TODO: redirect from web app fetch / request does not work as the request itself is redirected and not the page.
-        # try:
-        #     if action_id.startswith(ACTION_ACCESS):
-        #         port = action_id.split(ACTION_DELIMITER)[1]
+        if action_id == ACTION_START:
+            self._execute_start_service_action(project_id, service_id)
+        elif action_id == ACTION_STOP:
+            self._execute_stop_service_action(project_id, service_id)
+        elif action_id == ACTION_RESTART:
+            self._execute_restart_service_action(project_id, service_id)
+        else:
+            return Response(
+                content=f"No implementation for action id '{action_id}'",
+                status_code=501,
+            )
+        return Response(
+            content=f"Action {action_id} successfully executed.", status_code=200
+        )
 
-        #         return RedirectResponse(
-        #             url=f"{settings.CONTAXY_BASE_URL}/projects/{project_id}/services/{service_id}/access/{port}"
-        #         )
-        # except Exception:
-        #     raise ServerBaseError("Could not execute action")
+    def _execute_start_service_action(self, project_id: str, service_id: str) -> None:
+        service = self.get_service_metadata(project_id, service_id)
+        if service.status != DeploymentStatus.STOPPED:
+            raise ClientValueError(
+                f"Action {ACTION_START} on service {service_id} can only be performed "
+                f"when service is stopped but status is {service.status}!"
+            )
+        self.deployment_manager.deploy_service(
+            project_id, ServiceInput(**service.dict()), wait=True
+        )
 
-        # return Response(
-        #     content=f"No implementation for action id '{action_id}'", status_code=501
-        # )
-        raise NotImplementedError
+    def _execute_stop_service_action(self, project_id: str, service_id: str) -> None:
+        service = self.get_service_metadata(project_id, service_id)
+        if service.status == DeploymentStatus.STOPPED:
+            raise ClientValueError(
+                f"Action {ACTION_STOP} on service {service_id} can only be performed "
+                f"when service is not stopped already!"
+            )
+        self.deployment_manager.delete_service(
+            project_id, service_id, delete_volumes=False
+        )
+
+    def _execute_restart_service_action(
+        self, project_id: str, service_id: str
+    ) -> Service:
+        service = self.get_service_metadata(project_id, service_id)
+        if service.status == DeploymentStatus.STOPPED:
+            raise ClientValueError(
+                f"Action {ACTION_RESTART} on service {service_id} can only be performed "
+                f"when service is not stopped already!"
+            )
+        return self._restart_service(project_id, service)
+
+    def _restart_service(self, project_id: str, service: Service) -> Service:
+        self.deployment_manager.delete_service(
+            project_id, service.id, delete_volumes=False
+        )
+        self._wait_for_deployment_deletion(project_id, service.id)
+        return self.deployment_manager.deploy_service(
+            project_id, ServiceInput(**service.dict()), wait=True
+        )
+
+    def _wait_for_deployment_deletion(
+        self, project_id: str, service_id: str, timeout_seconds: int = 60
+    ) -> None:
+        try:
+            start_time = time.time()
+            while time.time() - start_time < timeout_seconds:
+                self.deployment_manager.get_service_metadata(project_id, service_id)
+                time.sleep(3)
+            raise ServerBaseError(
+                f"Action {ACTION_RESTART} on service {service_id} failed as service "
+                f"did not stop after waiting {timeout_seconds} seconds."
+            )
+        except ResourceNotFoundError:
+            # Service was successfully deleted
+            pass
 
     def execute_job_action(
         self, project_id: str, job_id: str, action_id: str
@@ -324,23 +392,48 @@ class DeploymentManagerWithDB(DeploymentOperations):
         )
 
         resource_actions: List[ResourceAction] = []
-        if service_metadata.endpoints:
-            for endpoint in service_metadata.endpoints:
-                endpoint = endpoint.replace("/", "")
-                resource_actions.append(
-                    ResourceAction(
-                        action_id=f"{ACTION_ACCESS}{ACTION_DELIMITER}{endpoint}",
-                        display_name=f"Endpoint: {endpoint}",
-                        instructions=[
-                            {
-                                "type": "new-tab",
-                                "url": f"{settings.CONTAXY_BASE_URL}/projects/{project_id}/services/{service_id}/access/{endpoint}",
-                            }
-                        ],
-                    )
-                )
+        if service_metadata.status == DeploymentStatus.STOPPED:
+            resource_actions.append(
+                ResourceAction(action_id=ACTION_START, display_name="Start Service")
+            )
+        else:
+            resource_actions.append(
+                ResourceAction(action_id=ACTION_STOP, display_name="Stop Service")
+            )
+            resource_actions.append(
+                ResourceAction(action_id=ACTION_RESTART, display_name="Restart Service")
+            )
+            resource_actions += self._get_service_access_actions(
+                project_id, service_id, service_metadata
+            )
 
         return resource_actions
+
+    @staticmethod
+    def _get_service_access_actions(
+        project_id: str, service_id: str, service_metadata: Service
+    ) -> List[ResourceAction]:
+        if not service_metadata.endpoints:
+            return []
+        access_actions = []
+        for endpoint in service_metadata.endpoints:
+            if len(service_metadata.endpoints) > 1:
+                display_name = f"Access Service on Endpoint: {endpoint}"
+            else:
+                display_name = "Access Service"
+            access_actions.append(
+                ResourceAction(
+                    action_id=f"{ACTION_ACCESS}{ACTION_DELIMITER}{endpoint.replace('/', '')}",
+                    display_name=display_name,
+                    instructions=[
+                        {
+                            "type": "new-tab",
+                            "url": f"{settings.CONTAXY_BASE_URL}/projects/{project_id}/services/{service_id}/access/{endpoint}",
+                        }
+                    ],
+                )
+            )
+        return access_actions
 
     def list_deploy_service_actions(
         self, project_id: str, service: ServiceInput

--- a/backend/src/contaxy/managers/deployment/manager.py
+++ b/backend/src/contaxy/managers/deployment/manager.py
@@ -45,9 +45,10 @@ class DeploymentManagerWithDB(DeploymentOperations):
         deployment_type: Literal[
             DeploymentType.SERVICE, DeploymentType.EXTENSION
         ] = DeploymentType.SERVICE,
+        wait: bool = False,
     ) -> Service:
         deployed_service = self.deployment_manager.deploy_service(
-            project_id, service, action_id, deployment_type
+            project_id, service, action_id, deployment_type, wait
         )
         self.json_db.create_json_document(
             project_id=config.SYSTEM_INTERNAL_PROJECT,
@@ -185,9 +186,15 @@ class DeploymentManagerWithDB(DeploymentOperations):
         return jobs
 
     def deploy_job(
-        self, project_id: str, job: JobInput, action_id: Optional[str] = None
+        self,
+        project_id: str,
+        job: JobInput,
+        action_id: Optional[str] = None,
+        wait: bool = False,
     ) -> Job:
-        deployed_job = self.deployment_manager.deploy_job(project_id, job, action_id)
+        deployed_job = self.deployment_manager.deploy_job(
+            project_id, job, action_id, wait
+        )
         self.json_db.create_json_document(
             project_id=config.SYSTEM_INTERNAL_PROJECT,
             collection_id=_get_job_collection_id(project_id),

--- a/backend/src/contaxy/operations/deployment.py
+++ b/backend/src/contaxy/operations/deployment.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Any, List, Literal, Optional
 
 from contaxy.schema import Job, JobInput, ResourceAction, Service, ServiceInput
-from contaxy.schema.deployment import DeploymentType
+from contaxy.schema.deployment import DeploymentType, ServiceUpdate
 
 # TODO: update_service functionality
 
@@ -91,6 +91,21 @@ class ServiceOperations(ABC):
 
         Returns:
             Service: The service metadata.
+        """
+        pass
+
+    @abstractmethod
+    def update_service(
+        self, project_id: str, service_id: str, service: ServiceUpdate
+    ) -> Service:
+        """Updates the service.
+
+        Args:
+            project_id (str): The project ID associated with the service.
+            service_id (str): The ID of the service.
+            service (ServiceUpdate): Updates that should be applied to the service
+        Returns:
+            Service: The updated service metadata
         """
         pass
 

--- a/backend/src/contaxy/operations/deployment.py
+++ b/backend/src/contaxy/operations/deployment.py
@@ -37,6 +37,7 @@ class ServiceOperations(ABC):
         deployment_type: Literal[
             DeploymentType.SERVICE, DeploymentType.EXTENSION
         ] = DeploymentType.SERVICE,
+        wait: bool = False,
     ) -> Service:
         """Deploys a service for the specified project.
 
@@ -48,10 +49,11 @@ class ServiceOperations(ABC):
         The action mechanism is further explained in the description of the [list_deploy_service_actions](#services/list_deploy_service_actions).
 
         Args:
-            project_id (str): [description]
-            service (ServiceInput): [description]
+            project_id (str): The id of the project that the service should be assigned to.
+            service (ServiceInput): The service input which can be used to configure the deployed service.
             action_id (Optional[str], optional): The ID of the selected action. Defaults to `None`.
             deployment_type (One of [DeploymentType.SERVICE, DeploymentType.JOB]): The deployment type of either Service or Extension (which is a subtype of Service).
+            wait (bool, optional): If set to True, the function will wait until the service was successfully created.
 
         Returns:
             Service: The metadata of the deployed service.
@@ -221,6 +223,7 @@ class JobOperations(ABC):
         project_id: str,
         job: JobInput,
         action_id: Optional[str] = None,
+        wait: bool = False,
     ) -> Job:
         pass
 

--- a/backend/src/contaxy/schema/deployment.py
+++ b/backend/src/contaxy/schema/deployment.py
@@ -241,6 +241,27 @@ class ServiceInput(ServiceBase, DeploymentInput):
     pass
 
 
+class ServiceUpdate(ServiceInput):
+    # Add default value for container_image so it is not required to be set in an update request
+    container_image: str = Field(
+        "",
+        example="hello-world:latest",
+        max_length=2000,
+        description="The container image used for this deployment.",
+    )
+    # Allow None for parameters and metadata values so they can be completely removed in an update request
+    parameters: Optional[Dict[str, Optional[str]]] = Field(  # type: ignore[assignment]
+        None,
+        example={"TEST_PARAM": "param-value"},
+        description="Parmeters (enviornment variables) for this deployment.",
+    )
+    metadata: Optional[Dict[str, Optional[str]]] = Field(  # type: ignore[assignment]
+        None,
+        example={"additional-metadata": "value"},
+        description="A collection of arbitrary key-value pairs associated with this resource that does not need predefined structure. Enable third-party integrations to decorate objects with additional metadata for their own use.",
+    )
+
+
 class Service(ServiceBase, Deployment):
     pass
 

--- a/backend/src/contaxy/schema/deployment.py
+++ b/backend/src/contaxy/schema/deployment.py
@@ -145,9 +145,13 @@ class DeploymentBase(BaseModel):
         None,
         description="Compute instructions and limitations for this deployment.",
     )
-    command: Optional[str] = Field(
+    command: Optional[List[str]] = Field(
         None,
-        description="Command to run within the deployment. This overwrites the existing entrypoint.",
+        description="Command to run within the deployment. This overwrites the existing docker ENTRYPOINT.",
+    )
+    args: Optional[List[str]] = Field(
+        None,
+        description="Arguments to the command/entrypoint. This overwrites the existing docker CMD.",
     )
     requirements: Optional[List[str]] = Field(
         None,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -45,7 +45,8 @@ def global_state() -> GlobalState:
 @pytest.fixture()
 def request_state() -> RequestState:
     """Initializes request state."""
-    return RequestState(State())
+    request_state = RequestState(State())
+    return request_state
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_deployment_operations.py
+++ b/backend/tests/test_deployment_operations.py
@@ -512,14 +512,13 @@ class TestDockerDeploymentManager(DeploymentOperationsTests):
 
     def deploy_service(self, project_id: str, service: ServiceInput) -> Service:
         deployed_service = self._deployment_manager.deploy_service(
-            project_id=project_id, service=service
+            project_id=project_id, service=service, wait=True
         )
-        time.sleep(2)
         return deployed_service
 
     def deploy_job(self, project_id: str, job: JobInput) -> Job:
         deployed_job = self._deployment_manager.deploy_job(
-            project_id=project_id, job=job
+            project_id=project_id, job=job, wait=True
         )
         time.sleep(3)
         return deployed_job
@@ -937,16 +936,14 @@ class DeploymentOperationsEndpointTests(DeploymentOperationsTests):
 
     def deploy_service(self, project_id: str, service: ServiceInput) -> Service:
         deployed_service = self._deployment_manager.deploy_service(
-            project_id=project_id, service=service
+            project_id=project_id, service=service, wait=True
         )
-        time.sleep(2)
         return deployed_service
 
     def deploy_job(self, project_id: str, job: JobInput) -> Job:
         deployed_job = self._deployment_manager.deploy_job(
-            project_id=project_id, job=job
+            project_id=project_id, job=job, wait=True
         )
-        time.sleep(3)
         return deployed_job
 
 


### PR DESCRIPTION
This pull request implements the following features for service deployments in contaxy:
1. The 'wait' query parameter is added to the deploy service endpoint. When it is set to true, the requests waits until the service is deployed (or fails after a 60 second timeout).
2. Add separate command and args field to the deployment class (with the same functionality they have in K8s). This makes it easier to restart services stored in the DB and gives more control over the docker container's ENTRYPOINT and CMD.
3. Add update endpoint for services that allows to change settings like the docker image, compute resources, parameters, etc. This will cause the underlying container to be recreated.
4. Use the service action list/execute endpoints to implement service start, stop and restart. These actions manipulate the underlying service container while keeping the service db entry unchanged.