### PR TITLE
Store initialization state in DB and ensure user registration/login is not possible before initialization

### DIFF
--- a/backend/src/contaxy/api/endpoints/user.py
+++ b/backend/src/contaxy/api/endpoints/user.py
@@ -17,8 +17,10 @@ from contaxy.schema.exceptions import (
     GET_RESOURCE_RESPONSES,
     UPDATE_RESOURCE_RESPONSES,
     VALIDATION_ERROR_RESPONSE,
+    ClientBaseError,
     PermissionDeniedError,
 )
+from contaxy.schema.system import SystemState
 from contaxy.utils import auth_utils, id_utils
 
 router = APIRouter(
@@ -66,6 +68,12 @@ def create_user(
 
     If the `password` is not provided, the user can only login by using other methods (social login).
     """
+    system_info = component_manager.get_system_manager().get_system_info()
+    if system_info.system_state != SystemState.RUNNING:
+        raise ClientBaseError(
+            status.HTTP_400_BAD_REQUEST,
+            "User registration is not possible before system has been initialized!",
+        )
 
     if not component_manager.global_state.settings.USER_REGISTRATION_ENABLED:
         if token is not None:

--- a/backend/src/contaxy/managers/auth.py
+++ b/backend/src/contaxy/managers/auth.py
@@ -669,7 +669,7 @@ class AuthManager(AuthOperations):
 
         except ResourceNotFoundError as ex:
             # The user was not found in the system
-            raise OAuth2Error("invalid_request") from ex
+            raise OAuth2Error("unauthorized_client") from ex
 
     def _generate_token(
         self, user_id: str, scopes: Union[str, List[str], None] = None

--- a/backend/src/contaxy/managers/json_db/postgres.py
+++ b/backend/src/contaxy/managers/json_db/postgres.py
@@ -338,7 +338,7 @@ class PostgresJsonDocumentManager(JsonDocumentOperations):
     def _map_db_row_to_document_model(self, row: Row) -> JsonDocument:
         data: Dict = {}
         for column_name, value in row._mapping.items():
-            if isinstance(value, dict):
+            if column_name == "json_value":
                 value = json.dumps(value)
             data.update({column_name: value})
         return JsonDocument(**data)

--- a/backend/src/contaxy/schema/system.py
+++ b/backend/src/contaxy/schema/system.py
@@ -6,8 +6,7 @@ from pydantic import BaseModel, Field, validator
 
 
 class SystemState(str, Enum):
-    STARTING = "starting"
-    INITIALIZING = "initializing"
+    UNINITIALIZED = "uninitialized"
     RUNNING = "running"
 
 
@@ -23,9 +22,7 @@ class SystemInfo(BaseModel):
         example="mlhub",
         description="Namespace of this system.",
     )
-    system_state: SystemState = Field(
-        SystemState.STARTING, description="The state of the system."
-    )
+    system_state: SystemState = Field(..., description="The state of the system.")
     metadata: Optional[Dict[str, str]] = Field(
         None,
         example={"additional-metadata": "value"},


### PR DESCRIPTION
Until now, the contaxy initialization endpoint could only be called as long as no users existed in the DB. As the initialization creates the default admin user, this prevented the initialization to be called more than once. However, a new user could be registered before the initialization was called, which means the initialization could not be done after that.

This PR introduces two main changes:
1. A flag is saved in the DB which indicates whether initialization was already done. To save this flag, a concept of "system properties" was added, which can be used for additional properties of the systems that need to be persisted in the future.
2. All user login and registration endpoints now check if the system is already initialized. If that's not the case, a 403 error response is returned.
