### PR TITLE
Refactor managers to use the ComponentManager to access other managers

### DIFF
--- a/backend/src/contaxy/clients/auth.py
+++ b/backend/src/contaxy/clients/auth.py
@@ -16,7 +16,7 @@ from contaxy.schema import (
     UserInput,
     UserRegistration,
 )
-from contaxy.schema.auth import ApiToken, OAuth2Error
+from contaxy.schema.auth import ApiToken, OAuth2Error, TokenPurpose
 
 
 def handle_oauth_error(response: Response) -> None:
@@ -37,8 +37,11 @@ class AuthClient(AuthOperations):
         scopes: List[str],
         token_type: TokenType,
         description: Optional[str] = None,
+        token_purpose: Optional[TokenPurpose] = None,
+        token_subject: Optional[str] = None,
         request_kwargs: Dict = {},
     ) -> str:
+        # TODO: Implement token_purpose and token_subject
         params = {"token_type": token_type.value, "scopes": scopes}
         if description:
             params["description"] = description
@@ -70,6 +73,18 @@ class AuthClient(AuthOperations):
         handle_errors(response)
 
     def add_permission(self, resource_name: str, permission: str) -> None:
+        # TODO: Implement
+        pass
+
+    def remove_permission(
+        self, resource_name: str, permission: str, remove_sub_permissions: bool = False
+    ) -> None:
+        # TODO: Implement
+        pass
+
+    def list_permissions(
+        self, resource_name: str, resolve_roles: bool = True, use_cache: bool = False
+    ) -> List[str]:
         # TODO: Implement
         pass
 

--- a/backend/src/contaxy/clients/system.py
+++ b/backend/src/contaxy/clients/system.py
@@ -56,3 +56,7 @@ class SystemClient(SystemOperations):
             **request_kwargs,
         )
         handle_errors(response)
+
+    def check_allowed_image(self, image_name: str, image_tag: str) -> None:
+        # TODO: Implement
+        pass

--- a/backend/src/contaxy/managers/deployment/docker_utils.py
+++ b/backend/src/contaxy/managers/deployment/docker_utils.py
@@ -9,7 +9,6 @@ import psutil
 from loguru import logger
 
 from contaxy.config import settings
-from contaxy.managers.auth import AuthManager
 from contaxy.managers.deployment.utils import (
     _MIN_MEMORY_DEFAULT_MB,
     DEFAULT_DEPLOYMENT_ACTION_ID,
@@ -28,6 +27,7 @@ from contaxy.managers.deployment.utils import (
     map_labels,
     replace_templates,
 )
+from contaxy.operations import AuthOperations
 from contaxy.schema import ResourceAction
 from contaxy.schema.deployment import (
     DeploymentCompute,
@@ -457,7 +457,7 @@ def define_mounts(
 def create_container_config(
     service: Union[JobInput, ServiceInput],
     project_id: str,
-    auth_manager: AuthManager,
+    auth_manager: AuthOperations,
     user_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     if service.display_name is None:

--- a/backend/src/contaxy/managers/deployment/kube_utils.py
+++ b/backend/src/contaxy/managers/deployment/kube_utils.py
@@ -32,7 +32,6 @@ from kubernetes.client.models import (
 from kubernetes.client.rest import ApiException
 
 from contaxy.config import settings
-from contaxy.managers.auth import AuthManager
 from contaxy.managers.deployment.utils import (
     _MIN_MEMORY_DEFAULT_MB,
     Labels,
@@ -45,6 +44,7 @@ from contaxy.managers.deployment.utils import (
     map_labels,
     replace_templates,
 )
+from contaxy.operations import AuthOperations
 from contaxy.schema import Job, JobInput, Service, ServiceInput
 from contaxy.schema.deployment import (
     DeploymentCompute,
@@ -209,7 +209,7 @@ def build_pod_template_spec(
     service_id: str,
     service: Union[ServiceInput, JobInput],
     metadata: V1ObjectMeta,
-    auth_manager: AuthManager,
+    auth_manager: AuthOperations,
     user_id: Optional[str] = None,
 ) -> V1PodTemplateSpec:
     compute_resources = service.compute or DeploymentCompute()
@@ -330,7 +330,7 @@ def build_kube_deployment_config(
     service: ServiceInput,
     project_id: str,
     kube_namespace: str,
-    auth_manager: AuthManager,
+    auth_manager: AuthOperations,
     user_id: Optional[str] = None,
 ) -> Tuple[V1Deployment, Union[V1PersistentVolumeClaim, None]]:
     # ---

--- a/backend/src/contaxy/managers/deployment/utils.py
+++ b/backend/src/contaxy/managers/deployment/utils.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
 from contaxy.config import settings
-from contaxy.managers.auth import AuthManager
+from contaxy.operations import AuthOperations
 from contaxy.schema import AccessLevel, TokenType, UnauthenticatedError
 from contaxy.schema.auth import TokenPurpose
 from contaxy.schema.deployment import DeploymentCompute, DeploymentType
@@ -233,7 +233,7 @@ def map_endpoints_label_to_endpoints(
 def get_default_environment_variables(
     project_id: str,
     deployment_id: str,
-    auth_manager: AuthManager,
+    auth_manager: AuthOperations,
     endpoints: Optional[List[str]] = None,
     compute_resources: Optional[DeploymentCompute] = None,
 ) -> Dict[str, str]:
@@ -242,7 +242,7 @@ def get_default_environment_variables(
     Args:
         project_id (str): The project id included in the label list
         deployment_id (str)
-        auth_manager (AuthManager): Auth manager used for creating an access token for the service
+        auth_manager (AuthOperations): Auth manager used for creating an access token for the service
         endpoints (List[str]): List of endpoints
         compute_resources: (Optional[DeploymentCompute]): DeploymentCompute information
 

--- a/backend/src/contaxy/managers/seed.py
+++ b/backend/src/contaxy/managers/seed.py
@@ -6,12 +6,12 @@ from faker import Faker
 from pydantic import EmailStr
 
 from contaxy.operations import AuthOperations, FileOperations, ProjectOperations
+from contaxy.operations.components import ComponentOperations
 from contaxy.operations.seed import SeedOperations
 from contaxy.schema import File, Project, User, UserRegistration
 from contaxy.schema.project import ProjectCreation
 from contaxy.utils import auth_utils
 from contaxy.utils.file_utils import FileStreamWrapper
-from contaxy.utils.state_utils import GlobalState, RequestState
 
 FAKER = Faker()
 Faker.seed(0)
@@ -22,17 +22,23 @@ ERROR_NO_PROJECT_MANAGER = "Seeder needs to be initialized with a project manage
 class SeedManager(SeedOperations):
     def __init__(
         self,
-        global_state: Optional[GlobalState] = None,
-        request_state: Optional[RequestState] = None,
-        auth_manager: Optional[AuthOperations] = None,
-        file_manager: Optional[FileOperations] = None,
-        project_manager: Optional[ProjectOperations] = None,
+        component_manager: ComponentOperations,
     ):
-        self.global_state = global_state
-        self.request_state = request_state
-        self.auth_manager = auth_manager
-        self.file_manager = file_manager
-        self.project_manager = project_manager
+        self.global_state = component_manager.global_state
+        self.request_state = component_manager.request_state
+        self._component_manager = component_manager
+
+    @property
+    def file_manager(self) -> FileOperations:
+        return self._component_manager.get_file_manager()
+
+    @property
+    def auth_manager(self) -> AuthOperations:
+        return self._component_manager.get_auth_manager()
+
+    @property
+    def project_manager(self) -> ProjectOperations:
+        return self._component_manager.get_project_manager()
 
     def create_user(
         self,

--- a/backend/src/contaxy/operations/auth.py
+++ b/backend/src/contaxy/operations/auth.py
@@ -11,7 +11,7 @@ from contaxy.schema import (
     UserInput,
     UserRegistration,
 )
-from contaxy.schema.auth import ApiToken
+from contaxy.schema.auth import ApiToken, TokenPurpose
 
 
 class AuthOperations(ABC):
@@ -21,6 +21,8 @@ class AuthOperations(ABC):
         scopes: List[str],
         token_type: TokenType,
         description: Optional[str] = None,
+        token_purpose: Optional[TokenPurpose] = None,
+        token_subject: Optional[str] = None,
     ) -> str:
         """Returns a session or API token with access to the speicfied scopes.
 
@@ -30,6 +32,8 @@ class AuthOperations(ABC):
             scopes: Scopes requested for this token. If none specified, the token will be generated with same set of scopes as the authorized token.
             token_type: The type of the token.
             description (optional): A short description about the generated token.
+            token_purpose: Purpose of the newly created token
+            token_subject: Subject that the token belongs to
 
         Returns:
             str: The created session or API token.
@@ -97,6 +101,49 @@ class AuthOperations(ABC):
 
         Raises:
             ResourceUpdateFailedError: If the resource update could not be applied successfully.
+        """
+        pass
+
+    @abstractmethod
+    def remove_permission(
+        self, resource_name: str, permission: str, remove_sub_permissions: bool = False
+    ) -> None:
+        """Revokes a permission from the specified resource.
+
+        Args:
+            resource_name: The resource name that the permission should be revoked from.
+            permission: The permission to revoke from the specified resource.
+            remove_sub_permissions: If `True`, the permission is used as prefix, and all permissions that start with this prefix will be revoked. Defaults to `False`.
+        """
+        pass
+
+    @abstractmethod
+    def list_permissions(
+        self, resource_name: str, resolve_roles: bool = True, use_cache: bool = False
+    ) -> List[str]:
+        """Returns all permissions granted to the specified resource.
+
+        Args:
+            resource_name: The name of the resource (relative URI).
+            resolve_roles: If `True`, all roles of the resource will be resolved to the associated permissions. Defaults to `True`.
+
+        Returns:
+            List[str]: List of permissions granted to the given resource.
+        """
+        pass
+
+    @abstractmethod
+    def list_resources_with_permission(
+        self, permission: str, resource_name_prefix: Optional[str] = None
+    ) -> List[str]:
+        """Returns all resources that are granted for the specified permission.
+
+        Args:
+            permission: The permission to use. If the permission is specified without the access level, it will filter for all access levels.
+            resource_name_prefix: Only return resources that match with this prefix.
+
+        Returns:
+            List[str]: List of resources names (relative URIs).
         """
         pass
 

--- a/backend/src/contaxy/operations/components.py
+++ b/backend/src/contaxy/operations/components.py
@@ -1,0 +1,98 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from contaxy.operations import (
+    AuthOperations,
+    ExtensionOperations,
+    FileOperations,
+    JobOperations,
+    JsonDocumentOperations,
+    ProjectOperations,
+    SeedOperations,
+    ServiceOperations,
+    SystemOperations,
+)
+from contaxy.schema.extension import CORE_EXTENSION_ID
+from contaxy.utils.state_utils import GlobalState, RequestState
+
+
+class ComponentOperations(ABC):
+    @property
+    @abstractmethod
+    def global_state(self) -> GlobalState:
+        pass
+
+    @property
+    @abstractmethod
+    def request_state(self) -> RequestState:
+        pass
+
+    @abstractmethod
+    def get_project_manager(self) -> ProjectOperations:
+        """Returns a Project Manager instance."""
+        pass
+
+    @abstractmethod
+    def get_auth_manager(self) -> AuthOperations:
+        """Returns an Auth Manager instance."""
+        pass
+
+    @abstractmethod
+    def get_system_manager(self) -> SystemOperations:
+        """Returns a System Manager instance."""
+        pass
+
+    @abstractmethod
+    def get_extension_manager(self) -> ExtensionOperations:
+        """Returns an Extension Manager instance."""
+        pass
+
+    @abstractmethod
+    def get_json_db_manager(self) -> JsonDocumentOperations:
+        """Returns a JSON DB Manager instance."""
+        pass
+
+    @abstractmethod
+    def get_file_manager(
+        self, extension_id: Optional[str] = CORE_EXTENSION_ID
+    ) -> FileOperations:
+        """Returns a File Manager instance.
+
+        Depending on the provided `extenion_id`, this is either the configured core component
+        or an initialized extension client.
+
+        Args:
+            extension_id: ID of the requested extension. Use `core` for the platform components.
+        """
+        pass
+
+    @abstractmethod
+    def get_job_manager(
+        self, extension_id: Optional[str] = CORE_EXTENSION_ID
+    ) -> JobOperations:
+        """Returns a Job Manager instance.
+
+        Depending on the provided `extenion_id`, this is either the configured core component
+        or an initialized extension client.
+
+        Args:
+            extension_id: ID of the requested extension. Use `core` for the platform components.
+        """
+        pass
+
+    def get_service_manager(
+        self, extension_id: Optional[str] = CORE_EXTENSION_ID
+    ) -> ServiceOperations:
+        """Returns a Service Manager instance.
+
+        Depending on the provided `extenion_id`, this is either the configured core component
+        or an initialized extension client.
+
+        Args:
+            extension_id: ID of the requested extension. Use `core` for the platform components.
+        """
+        pass
+
+    @abstractmethod
+    def get_seed_manager(self) -> SeedOperations:
+        pass

--- a/backend/src/contaxy/operations/system.py
+++ b/backend/src/contaxy/operations/system.py
@@ -32,3 +32,7 @@ class SystemOperations(ABC):
     @abstractmethod
     def delete_allowed_image(self, allowed_image_name: str) -> None:
         pass
+
+    @abstractmethod
+    def check_allowed_image(self, image_name: str, image_tag: str) -> None:
+        pass

--- a/backend/tests/test_auth_operations.py
+++ b/backend/tests/test_auth_operations.py
@@ -26,6 +26,7 @@ from contaxy.utils import id_utils
 from contaxy.utils.state_utils import GlobalState, RequestState
 
 from .conftest import test_settings
+from .utils import ComponentManagerMock
 
 DEFAULT_USERS_TO_GENERATE = 10
 
@@ -479,7 +480,9 @@ class TestAuthManagerWithPostgresDB(AuthOperationsTests):
         json_db = PostgresJsonDocumentManager(global_state, request_state)
         # Cleanup everything at the startup
         json_db.delete_json_collections(config.SYSTEM_INTERNAL_PROJECT)
-        self._auth_manager = AuthManager(global_state, request_state, json_db)
+        self._auth_manager = AuthManager(
+            ComponentManagerMock(global_state, request_state, json_db_manager=json_db)
+        )
         yield
         json_db.delete_json_collections(config.SYSTEM_INTERNAL_PROJECT)
         # Do cleanup
@@ -497,7 +500,9 @@ class TestAuthManagerWithInMemoryDB(AuthOperationsTests):
     ) -> Generator:
         json_db = InMemoryDictJsonDocumentManager(global_state, request_state)
         json_db.delete_json_collections(config.SYSTEM_INTERNAL_PROJECT)
-        self._auth_manager = AuthManager(global_state, request_state, json_db)
+        self._auth_manager = AuthManager(
+            ComponentManagerMock(global_state, request_state, json_db_manager=json_db)
+        )
         yield
         json_db.delete_json_collections(config.SYSTEM_INTERNAL_PROJECT)
 

--- a/backend/tests/utils.py
+++ b/backend/tests/utils.py
@@ -1,1 +1,77 @@
 """Shared Testing Utilities."""
+from typing import Optional, Union
+
+from contaxy.managers.auth import AuthManager
+from contaxy.managers.extension import ExtensionManager
+from contaxy.managers.project import ProjectManager
+from contaxy.managers.system import SystemManager
+from contaxy.operations import (
+    FileOperations,
+    JobOperations,
+    JsonDocumentOperations,
+    SeedOperations,
+    ServiceOperations,
+)
+from contaxy.operations.components import ComponentOperations
+from contaxy.utils.state_utils import GlobalState, RequestState
+
+
+class ComponentManagerMock(ComponentOperations):
+    def __init__(
+        self,
+        global_state: Optional[GlobalState] = None,
+        request_state: Optional[RequestState] = None,
+        project_manager: Optional[ProjectManager] = None,
+        auth_manager: Optional[AuthManager] = None,
+        system_manager: Optional[SystemManager] = None,
+        extension_manager: Optional[ExtensionManager] = None,
+        json_db_manager: Optional[JsonDocumentOperations] = None,
+        file_manager: Optional[FileOperations] = None,
+        deployment_manager: Optional[Union[JobOperations, ServiceOperations]] = None,
+        seed_manager: Optional[SeedOperations] = None,
+    ):
+        self._global_state = global_state
+        self._request_state = request_state
+        self.project_manager = project_manager
+        self.auth_manager = auth_manager
+        self.system_manager = system_manager
+        self.extension_manager = extension_manager
+        self.json_db_manager = json_db_manager
+        self.file_manager = file_manager
+        self.deployment_manager = deployment_manager
+        self.seed_manager = seed_manager
+
+    @property
+    def global_state(self) -> GlobalState:
+        return self._global_state
+
+    @property
+    def request_state(self) -> RequestState:
+        return self._request_state
+
+    def get_project_manager(self) -> ProjectManager:
+        return self.project_manager
+
+    def get_auth_manager(self) -> AuthManager:
+        return self.auth_manager
+
+    def get_system_manager(self) -> SystemManager:
+        return self.system_manager
+
+    def get_extension_manager(self) -> ExtensionManager:
+        return self.extension_manager
+
+    def get_json_db_manager(self) -> JsonDocumentOperations:
+        return self.json_db_manager
+
+    def get_file_manager(self) -> FileOperations:
+        return self.file_manager
+
+    def get_job_manager(self) -> JobOperations:
+        return self.deployment_manager
+
+    def get_service_manager(self) -> ServiceOperations:
+        return self.deployment_manager
+
+    def get_seed_manager(self) -> SeedOperations:
+        return self.seed_manager


### PR DESCRIPTION
The different managers in contaxy (e.g. SystemManager, AuthManager, etc.) need access to other managers. So far, these dependent managers were passed via the constructor directly. 
However, for some of the managers a cyclic dependency can arise. For example the ServiceManager needs the AuthManager to generate self access tokens for newly created services. But at the same time, the AuthManager should use the ServiceManager to update the "last accessed" timestamp of a service when a new session token for that service is generated. To allow this kind of dependency, instead of passing the AuthManager directly to the ServiceManager, instead, the ComponentManager is passed which can be used to retrieve the AuthManager. 
In the constructor of the ServiceManager, the get_auth_manager() function must not be called directly (as this would lead to a dependency loop again). Instead, a property for each required manager is defined, that calls the respective getter method of the ComponentManager. This also improves the lazy loading of the managers, as the getter function is only called, if the manager is actually required.

This change also required to use the "operations" abstract base classes in all signatures instead of the concrete "manager" classes (e.g. SystemOperations instead of SystemManager). Some methods were only implemented in the manager classes and not in the respective abstract base class. These missing functions were added, but the corresponding implementation in the client classes where left black for now.