### PR TITLE
Volume path of service is not shown when requesting service information via the API

### DIFF
--- a/backend/src/contaxy/managers/deployment/docker_utils.py
+++ b/backend/src/contaxy/managers/deployment/docker_utils.py
@@ -549,6 +549,7 @@ def create_container_config(
             Labels.ENDPOINTS.value: endpoints_label,
             Labels.REQUIREMENTS.value: requirements_label,
             Labels.CREATED_BY.value: user_id,
+            Labels.VOLUME_PATH.value: compute_resources.volume_path or "",
             **metadata,
         },
         "name": container_name,

--- a/backend/src/contaxy/managers/deployment/kube_utils.py
+++ b/backend/src/contaxy/managers/deployment/kube_utils.py
@@ -320,6 +320,7 @@ def build_deployment_metadata(
             Labels.MIN_LIFETIME.value: str(min_lifetime),
             Labels.ENDPOINTS.value: map_endpoints_to_endpoints_label(endpoints),
             Labels.CREATED_BY.value: user_id,
+            Labels.VOLUME_PATH.value: _compute_resources.volume_path or "",
             **cleaned_labels,
         },
     )
@@ -549,7 +550,7 @@ def map_deployment(deployment: Union[V1Deployment, V1Job]) -> Dict[str, Any]:
         ),  # / 1000 / 1000,
         max_gpus=None,  # TODO: fill with sensible information - where to get it from?
         min_lifetime=mapped_labels.min_lifetime,
-        volume_Path=mapped_labels.volume_path,
+        volume_path=mapped_labels.volume_path,
         # TODO: add max_volume_size, max_replicas
     )
 

--- a/backend/tests/test_deployment_operations.py
+++ b/backend/tests/test_deployment_operations.py
@@ -76,6 +76,7 @@ def create_test_service_input(display_name: str) -> ServiceInput:
         compute={
             "max_cpus": 2,
             "max_memory": 100,
+            "volume_path": "/test",
         },  # TODO: Also test persistent volumes
         display_name=display_name,
         description="This is a test service",
@@ -146,6 +147,7 @@ class DeploymentOperationsTests(ABC):
         assert service.metadata.get(Labels.PROJECT_NAME.value, "") == self.project_id
         assert service.parameters.get("FOO", "") == "bar"
         assert "some-metadata" in service.metadata
+        assert service.compute.volume_path == "/test"
 
     def test_update_service(self) -> None:
         test_service_input = create_test_service_input(
@@ -254,6 +256,7 @@ class DeploymentOperationsTests(ABC):
             self.project_id, service.id
         )
         assert service.status == DeploymentStatus.RUNNING
+        assert service.compute.volume_path == "/test"
 
     def test_restart_service(self) -> None:
         test_service_input = create_test_service_input(


### PR DESCRIPTION
When listing the information of a service via the API, it the volume_path is always empty.
The current code is reading the volume_path from a label/annotation but that label/annotation is never set on service creation.
This PR adds that missing part and also a test that verifies it is working now.