### PR TITLE
Fix remote endpoint integration tests

### DIFF
--- a/backend/src/contaxy/managers/auth.py
+++ b/backend/src/contaxy/managers/auth.py
@@ -640,9 +640,9 @@ class AuthManager(AuthOperations):
                 ).permissions
             ):
                 continue
-            if resource_name_prefix and resource_name.startswith(resource_name_prefix):
-                resource_names.add(resource_name)
-            else:
+            if (not resource_name_prefix) or resource_name.startswith(
+                resource_name_prefix
+            ):
                 resource_names.add(resource_name)
         return list(resource_names)
 

--- a/backend/src/contaxy/managers/deployment/manager.py
+++ b/backend/src/contaxy/managers/deployment/manager.py
@@ -89,6 +89,8 @@ class DeploymentManagerWithDB(DeploymentOperations):
         # Go through all services in the DB and update their status and internal id
         for service_doc in service_docs:
             db_service = Service.parse_raw(service_doc.json_value)
+            if db_service.deployment_type != deployment_type:
+                continue
             deployed_service = deployed_service_lookup.pop(db_service.id, None)
             if deployed_service is None:
                 db_service.status = DeploymentStatus.STOPPED

--- a/backend/src/contaxy/managers/project.py
+++ b/backend/src/contaxy/managers/project.py
@@ -238,10 +238,16 @@ class ProjectManager(ProjectOperations):
         for resource_name in project_member_resource_names:
             try:
                 user_id = id_utils.extract_user_id_from_resource_name(resource_name)
-                project_users.append(self._auth_manager.get_user(user_id))
             except ValueError:
                 logger.warning(
                     "Failed to extract user id from resource name: " + resource_name
+                )
+                continue
+            try:
+                project_users.append(self._auth_manager.get_user(user_id))
+            except ResourceNotFoundError:
+                logger.warning(
+                    f"User with id {user_id} does not exist anymore but its permissions have not been removed from the DB!"
                 )
                 continue
 
@@ -278,7 +284,6 @@ class ProjectManager(ProjectOperations):
             ),
             remove_sub_permissions=True,
         )
-        print("test")
 
     def remove_project_member(self, project_id: str, user_id: str) -> List[User]:
         # Remove all permissions from the user that grant access to any part of the project

--- a/backend/tests/test_auth_operations.py
+++ b/backend/tests/test_auth_operations.py
@@ -163,6 +163,14 @@ class AuthOperationsTests(ABC):
             == 2
         )
         assert (
+            len(
+                self.auth_manager.list_resources_with_permission(
+                    PROJECT_PERMISSION_1, "other-prefix/"
+                )
+            )
+            == 0
+        )
+        assert (
             len(self.auth_manager.list_resources_with_permission(PROJECT_PERMISSION_2))
             == 1
         )

--- a/backend/tests/test_extensions_operations.py
+++ b/backend/tests/test_extensions_operations.py
@@ -6,12 +6,7 @@ import pytest
 import requests
 
 from contaxy import config
-from contaxy.clients import (
-    AuthClient,
-    DeploymentManagerClient,
-    ExtensionClient,
-    SystemClient,
-)
+from contaxy.clients import AuthClient, DeploymentManagerClient, ExtensionClient
 from contaxy.managers.extension import ExtensionInput
 from contaxy.operations.deployment import DeploymentOperations
 from contaxy.operations.extension import ExtensionOperations
@@ -177,11 +172,9 @@ class TestExtensionManagerViaRemoteEndpoint(ExtensionOperationsTests):
 
     @pytest.fixture(autouse=True)
     def _init_managers(self, _client: requests.Session) -> Generator:
-        system_manager = SystemClient(_client)
         self._auth_manager = AuthClient(_client)
         self._deployment_manager = DeploymentManagerClient(_client)
         self._extension_manager = ExtensionClient(_client)
-        system_manager.initialize_system()
 
         self.login_user(
             config.SYSTEM_ADMIN_USERNAME, config.SYSTEM_ADMIN_INITIAL_PASSWORD

--- a/backend/tests/test_file_operations.py
+++ b/backend/tests/test_file_operations.py
@@ -467,7 +467,6 @@ class TestMinioFileManagerViaRemoteEndpoints(FileOperationsTests):
     @pytest.fixture(autouse=True)
     def _init_managers(self, remote_client: requests.Session) -> Generator:
         self._endpoint_client = remote_client
-        system_manager = SystemClient(self._endpoint_client)
         self._json_db = JsonDocumentClient(self._endpoint_client)
         self._auth_manager = AuthClient(self._endpoint_client)
         self._file_manager = FileClient(self._endpoint_client)
@@ -476,7 +475,6 @@ class TestMinioFileManagerViaRemoteEndpoints(FileOperationsTests):
         )
 
         self._project_id = f"{randint(1, 100000)}-file-manager-test"
-        system_manager.initialize_system()
 
         self.login_user(
             config.SYSTEM_ADMIN_USERNAME, config.SYSTEM_ADMIN_INITIAL_PASSWORD

--- a/backend/tests/test_json_db_operations.py
+++ b/backend/tests/test_json_db_operations.py
@@ -466,11 +466,9 @@ class TestJsonDocumentManagerViaRemoteEndpoints(JsonDocumentOperationsTests):
     @pytest.fixture(autouse=True)
     def _init_managers(self, remote_client: requests.Session) -> Generator:
         self._endpoint_client = remote_client
-        system_manager = SystemClient(self._endpoint_client)
         self._json_db = JsonDocumentClient(self._endpoint_client)
         self._auth_manager = AuthClient(self._endpoint_client)
         self._project_id = f"{randint(1, 100000)}-file-manager-test"
-        system_manager.initialize_system()
 
         self.login_user(
             config.SYSTEM_ADMIN_USERNAME, config.SYSTEM_ADMIN_INITIAL_PASSWORD


### PR DESCRIPTION
There are some issues that prevented the remote endpoint tests to run successfully on the current code.
Moreover, the remote endpoints left quite a lot of resources (users, projects, services, etc.) on the remote instance. The tests were adjusted to do some more cleanup after each test.