### PR TITLE
Track last access time and user for all services via session token creation.

### DIFF
--- a/backend/src/contaxy/api/endpoints/deployment.py
+++ b/backend/src/contaxy/api/endpoints/deployment.py
@@ -265,6 +265,29 @@ def update_service(
     )
 
 
+@service_router.post(
+    "/projects/{project_id}/services/{service_id}:update-service-access",
+    operation_id=ExtensibleOperations.UPDATE_SERVICE_ACCESS.value,
+    summary="Update a service.",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={**UPDATE_RESOURCE_RESPONSES},
+)
+def update_service_access(
+    project_id: str = PROJECT_ID_PARAM,
+    service_id: str = SERVICE_ID_PARAM,
+    component_manager: ComponentManager = Depends(get_component_manager),
+    token: str = Depends(get_api_token),
+) -> Any:
+    """Update the last access information of the service to the current time and calling user."""
+    component_manager.verify_access(
+        token, f"projects/{project_id}/services/{service_id}", AccessLevel.WRITE
+    )
+    service_id, extension_id = parse_composite_id(service_id)
+    component_manager.get_service_manager(extension_id).update_service_access(
+        project_id, service_id
+    )
+
+
 @service_router.delete(
     "/projects/{project_id}/services",
     operation_id=ExtensibleOperations.DELETE_SERVICES.value,

--- a/backend/src/contaxy/clients/deployment.py
+++ b/backend/src/contaxy/clients/deployment.py
@@ -75,6 +75,18 @@ class DeploymentManagerClient(DeploymentOperations):
         handle_errors(resource)
         return parse_raw_as(Service, resource.text)
 
+    def update_service_access(
+        self,
+        project_id: str,
+        service_id: str,
+        request_kwargs: Dict = {},
+    ) -> None:
+        resource = self.client.post(
+            f"/projects/{project_id}/services/{service_id}:update-service-access",
+            **request_kwargs,
+        )
+        handle_errors(resource)
+
     def list_deploy_service_actions(
         self,
         project_id: str,

--- a/backend/src/contaxy/managers/deployment/docker.py
+++ b/backend/src/contaxy/managers/deployment/docker.py
@@ -126,6 +126,10 @@ class DockerDeploymentManager(DeploymentOperations):
         # Service update is only implemented on DeploymentManagerWithDB wrapper
         raise NotImplementedError()
 
+    def update_service_access(self, project_id: str, service_id: str) -> None:
+        # Service update is only implemented on DeploymentManagerWithDB wrapper
+        raise NotImplementedError()
+
     def delete_service(
         self, project_id: str, service_id: str, delete_volumes: bool = False
     ) -> None:

--- a/backend/src/contaxy/managers/deployment/kubernetes.py
+++ b/backend/src/contaxy/managers/deployment/kubernetes.py
@@ -244,6 +244,10 @@ class KubernetesDeploymentManager(DeploymentOperations):
         # Service update is only implemented on DeploymentManagerWithDB wrapper
         raise NotImplementedError()
 
+    def update_service_access(self, project_id: str, service_id: str) -> None:
+        # Service update is only implemented on DeploymentManagerWithDB wrapper
+        raise NotImplementedError()
+
     def list_deploy_service_actions(
         self, project_id: str, service: ServiceInput
     ) -> List[ResourceAction]:

--- a/backend/src/contaxy/operations/deployment.py
+++ b/backend/src/contaxy/operations/deployment.py
@@ -5,8 +5,6 @@ from typing import Any, List, Literal, Optional
 from contaxy.schema import Job, JobInput, ResourceAction, Service, ServiceInput
 from contaxy.schema.deployment import DeploymentType, ServiceUpdate
 
-# TODO: update_service functionality
-
 
 class ServiceOperations(ABC):
     @abstractmethod
@@ -106,6 +104,16 @@ class ServiceOperations(ABC):
             service (ServiceUpdate): Updates that should be applied to the service
         Returns:
             Service: The updated service metadata
+        """
+        pass
+
+    @abstractmethod
+    def update_service_access(self, project_id: str, service_id: str) -> None:
+        """Updates the last time the service was accessed and by which user.
+
+        Args:
+            project_id (str): The project ID associated with the service.
+            service_id (str): The ID of the service.
         """
         pass
 

--- a/backend/src/contaxy/schema/deployment.py
+++ b/backend/src/contaxy/schema/deployment.py
@@ -263,7 +263,13 @@ class ServiceUpdate(ServiceInput):
 
 
 class Service(ServiceBase, Deployment):
-    pass
+    # Store the last time this service was accessed and by which user
+    last_access_time: Optional[datetime] = Field(
+        None, description="Timestamp of the last time the service was accessed."
+    )
+    last_access_user: Optional[str] = Field(
+        None, description="Id of the user that last accessed the service."
+    )
 
 
 class JobBase(BaseModel):

--- a/backend/src/contaxy/schema/shared.py
+++ b/backend/src/contaxy/schema/shared.py
@@ -100,6 +100,7 @@ class ExtensibleOperations(str, Enum):
     DELETE_SERVICE = "delete_service"
     DELETE_SERVICES = "delete_services"
     UPDATE_SERVICE = "update_service"
+    UPDATE_SERVICE_ACCESS = "update_service_access"
     GET_SERVICE_LOGS = "get_service_logs"
     LIST_SERVICE_ACTIONS = "list_service_actions"
     EXECUTE_SERVICE_ACTION = "execute_service_action"

--- a/backend/src/contaxy/utils/id_utils.py
+++ b/backend/src/contaxy/utils/id_utils.py
@@ -6,7 +6,7 @@ import re
 import secrets
 import string
 from email.utils import parseaddr
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import shortuuid
 from slugify import slugify
@@ -16,6 +16,7 @@ from contaxy.config import settings
 _PROJECT_ID_SEPERATOR = "-p-"
 _PROJECT_NAME_TO_ID_REGEX = re.compile(r"^projects/([^/:\s]+)$")
 _USER_NAME_TO_ID_REGEX = re.compile(r"^users/([^/:\s]+)$")
+_SERVICE_RESOURCE_REGEX = re.compile(r"^projects/([^/:\s]+)/services/([^/:\s]+)")
 
 
 def is_email(text: str) -> bool:
@@ -53,6 +54,26 @@ def extract_project_id_from_resource_name(project_resource_name: str) -> str:
         raise ValueError(
             f"The provided project_resource_name is not valid: {project_resource_name}"
         )
+
+
+def extract_ids_from_service_resource_name(
+    service_resource_name: str,
+) -> Tuple[str, str]:
+    """Extract the project id and service id from a service resource name.
+
+    Args:
+        service_resource_name (str): The service resource name (e.g. /projects/project-id/services/service-id)
+
+    Returns:
+        Tuple[str, str]: The project id and service id contained in the resource name
+    """
+    match = _SERVICE_RESOURCE_REGEX.match(service_resource_name)
+    if match is None:
+        raise ValueError(
+            f"Resource name {service_resource_name} is not a service resource!"
+        )
+    groups = match.groups()
+    return groups[0], groups[1]
 
 
 def get_project_resource_prefix(project_id: str) -> str:


### PR DESCRIPTION
For some use cases it is required to track the last time a contaxy service was accessed (e.g. automatically stop a service has not been used for a certain time).
This PR adds the properties last_access_time and last_access_user to the Service object that track when the service was last accessed and by which user. These values can be updated via a new endpoint `/projects/{project_id}/services/{service_id}:update-service-access`. Additionally, they are automatically updated if a new session token for a service is requested. As the session tokens are short-lived, this will cause a regular update of the last access time if the service is actively used.