### PR TITLE
Add endpoints for listing, adding and deleting permissions

### DIFF
--- a/backend/src/contaxy/api/endpoints/auth.py
+++ b/backend/src/contaxy/api/endpoints/auth.py
@@ -172,6 +172,87 @@ def list_api_tokens(
     )
 
 
+@router.get(
+    "/auth/permissions",
+    summary="Lists roles for given resource.",
+    operation_id=CoreOperations.GET_RESOURCE_PERMISSIONS.value,
+    response_model=List[str],
+)
+def get_resource_permissions(
+    resource_name: str,
+    resolve_roles: bool = True,
+    use_cache: bool = True,
+    token: str = Depends(get_api_token),
+    component_manager: ComponentManager = Depends(get_component_manager),
+) -> Any:
+    """Lists the roles for a given resource, admin access for that resource is required."""
+    component_manager.verify_access(token, resource_name, AccessLevel.ADMIN)
+
+    return component_manager.get_auth_manager().list_permissions(
+        resource_name, resolve_roles, use_cache
+    )
+
+
+@router.post(
+    "/auth/permissions",
+    summary="Sets Permission for resource.",
+    operation_id=CoreOperations.SET_RESOURCE_PERMISSIONS.value,
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def set_resource_permissions(
+    resource_name: str,
+    permission: str,
+    token: str = Depends(get_api_token),
+    component_manager: ComponentManager = Depends(get_component_manager),
+) -> Any:
+    """Sets Permission for resource, admin access for that resource is required."""
+    component_manager.verify_access(token, resource_name, AccessLevel.ADMIN)
+
+    component_manager.get_auth_manager().add_permission(resource_name, permission)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.delete(
+    "/auth/permissions",
+    summary="Deletes Permission for resource.",
+    operation_id=CoreOperations.DELETE_RESOURCE_PERMISSIONS.value,
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def delete_resource_permissions(
+    resource_name: str,
+    permission: str,
+    remove_sub_permissions: bool = False,
+    token: str = Depends(get_api_token),
+    component_manager: ComponentManager = Depends(get_component_manager),
+) -> Any:
+    """Deletes Permission for resource, admin access for that resource is required."""
+    component_manager.verify_access(token, resource_name, AccessLevel.ADMIN)
+
+    component_manager.get_auth_manager().remove_permission(
+        resource_name, permission, remove_sub_permissions
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get(
+    "/auth/resources",
+    summary="List all resources that have a certain permission.",
+    operation_id=CoreOperations.GET_RESOURCES_WITH_PERMISSION.value,
+)
+def list_resources_with_permission(
+    permission: str,
+    resource_name_prefix: str,
+    token: str = Depends(get_api_token),
+    component_manager: ComponentManager = Depends(get_component_manager),
+) -> Any:
+    """List all resources that have a certain permission, admin access for that resource is required."""
+    component_manager.verify_access(token, AccessLevel.ADMIN)
+
+    component_manager.get_auth_manager().list_resources_with_permission(
+        permission, resource_name_prefix
+    )
+
+
 @router.post(
     "/auth/tokens",
     operation_id=CoreOperations.CREATE_TOKEN.value,

--- a/backend/src/contaxy/api/endpoints/auth.py
+++ b/backend/src/contaxy/api/endpoints/auth.py
@@ -196,18 +196,18 @@ def list_resource_permissions(
 
 @router.post(
     "/auth/permissions",
-    summary="Sets permission for resource.",
+    summary="Add permission to specified resource.",
     operation_id=CoreOperations.SET_RESOURCE_PERMISSIONS.value,
     status_code=status.HTTP_204_NO_CONTENT,
 )
-def set_resource_permissions(
+def add_resource_permission(
     resource_name: str,
     permission: str,
     token: str = Depends(get_api_token),
     component_manager: ComponentManager = Depends(get_component_manager),
 ) -> Any:
-    """Sets permission for resource, admin access for that resource is required."""
-    component_manager.verify_access(token, resource_name, AccessLevel.ADMIN)
+    """Adds permission to specified resource, admin access to the /auth/permissions resource is required."""
+    component_manager.verify_access(token, "/auth/permissions", AccessLevel.ADMIN)
 
     component_manager.get_auth_manager().add_permission(resource_name, permission)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
@@ -215,7 +215,7 @@ def set_resource_permissions(
 
 @router.delete(
     "/auth/permissions",
-    summary="Deletes permission for resource.",
+    summary="Deletes permission of specified resource.",
     operation_id=CoreOperations.DELETE_RESOURCE_PERMISSIONS.value,
     status_code=status.HTTP_204_NO_CONTENT,
 )
@@ -226,8 +226,8 @@ def delete_resource_permissions(
     token: str = Depends(get_api_token),
     component_manager: ComponentManager = Depends(get_component_manager),
 ) -> Any:
-    """Deletes permission for resource, admin access for that resource is required."""
-    #   component_manager.verify_access(token, "/auth/permissions", AccessLevel.ADMIN)
+    """Deletes permission of specified resource, admin access to the /auth/permissions resource is required."""
+    component_manager.verify_access(token, "/auth/permissions", AccessLevel.ADMIN)
 
     component_manager.get_auth_manager().remove_permission(
         resource_name, permission, remove_sub_permissions
@@ -248,8 +248,8 @@ def list_resources_with_permission(
     token: str = Depends(get_api_token),
     component_manager: ComponentManager = Depends(get_component_manager),
 ) -> Any:
-    """List all resources that have a certain permission, admin access for that resource is required."""
-    component_manager.verify_access(token, "/auth/permissions", AccessLevel.ADMIN)
+    """List all resources that have a certain permission, admin access to the /auth/resources resource is required."""
+    component_manager.verify_access(token, "/auth/resources", AccessLevel.ADMIN)
 
     component_manager.get_auth_manager().list_resources_with_permission(
         permission, resource_name_prefix

--- a/backend/src/contaxy/api/endpoints/auth.py
+++ b/backend/src/contaxy/api/endpoints/auth.py
@@ -174,18 +174,19 @@ def list_api_tokens(
 
 @router.get(
     "/auth/permissions",
-    summary="Lists roles for given resource.",
-    operation_id=CoreOperations.GET_RESOURCE_PERMISSIONS.value,
+    summary="Lists permissions for given resource.",
+    operation_id=CoreOperations.LIST_RESOURCE_PERMISSIONS.value,
+    status_code=status.HTTP_200_OK,
     response_model=List[str],
 )
-def get_resource_permissions(
+def list_resource_permissions(
     resource_name: str,
     resolve_roles: bool = True,
     use_cache: bool = True,
     token: str = Depends(get_api_token),
     component_manager: ComponentManager = Depends(get_component_manager),
 ) -> Any:
-    """Lists the roles for a given resource, admin access for that resource is required."""
+    """Lists the permissions for a given resource, admin access for that resource is required."""
     component_manager.verify_access(token, resource_name, AccessLevel.ADMIN)
 
     return component_manager.get_auth_manager().list_permissions(
@@ -195,7 +196,7 @@ def get_resource_permissions(
 
 @router.post(
     "/auth/permissions",
-    summary="Sets Permission for resource.",
+    summary="Sets permission for resource.",
     operation_id=CoreOperations.SET_RESOURCE_PERMISSIONS.value,
     status_code=status.HTTP_204_NO_CONTENT,
 )
@@ -205,7 +206,7 @@ def set_resource_permissions(
     token: str = Depends(get_api_token),
     component_manager: ComponentManager = Depends(get_component_manager),
 ) -> Any:
-    """Sets Permission for resource, admin access for that resource is required."""
+    """Sets permission for resource, admin access for that resource is required."""
     component_manager.verify_access(token, resource_name, AccessLevel.ADMIN)
 
     component_manager.get_auth_manager().add_permission(resource_name, permission)
@@ -214,7 +215,7 @@ def set_resource_permissions(
 
 @router.delete(
     "/auth/permissions",
-    summary="Deletes Permission for resource.",
+    summary="Deletes permission for resource.",
     operation_id=CoreOperations.DELETE_RESOURCE_PERMISSIONS.value,
     status_code=status.HTTP_204_NO_CONTENT,
 )
@@ -225,8 +226,8 @@ def delete_resource_permissions(
     token: str = Depends(get_api_token),
     component_manager: ComponentManager = Depends(get_component_manager),
 ) -> Any:
-    """Deletes Permission for resource, admin access for that resource is required."""
-    component_manager.verify_access(token, resource_name, AccessLevel.ADMIN)
+    """Deletes permission for resource, admin access for that resource is required."""
+    #   component_manager.verify_access(token, "/auth/permissions", AccessLevel.ADMIN)
 
     component_manager.get_auth_manager().remove_permission(
         resource_name, permission, remove_sub_permissions
@@ -238,6 +239,8 @@ def delete_resource_permissions(
     "/auth/resources",
     summary="List all resources that have a certain permission.",
     operation_id=CoreOperations.GET_RESOURCES_WITH_PERMISSION.value,
+    status_code=status.HTTP_200_OK,
+    response_model=List[str],
 )
 def list_resources_with_permission(
     permission: str,
@@ -246,7 +249,7 @@ def list_resources_with_permission(
     component_manager: ComponentManager = Depends(get_component_manager),
 ) -> Any:
     """List all resources that have a certain permission, admin access for that resource is required."""
-    component_manager.verify_access(token, AccessLevel.ADMIN)
+    component_manager.verify_access(token, "/auth/permissions", AccessLevel.ADMIN)
 
     component_manager.get_auth_manager().list_resources_with_permission(
         permission, resource_name_prefix

--- a/backend/src/contaxy/schema/shared.py
+++ b/backend/src/contaxy/schema/shared.py
@@ -42,6 +42,10 @@ class CoreOperations(str, Enum):
     CREATE_TOKEN = "create_token"
     LOGOUT_USER_SESSION = "logout_user_session"
     LOGIN_USER_SESSION = "login_user_session"
+    GET_RESOURCE_PERMISSIONS = "get_resource_permissions"
+    SET_RESOURCE_PERMISSIONS = "set_resource_permissions"
+    DELETE_RESOURCE_PERMISSIONS = "delete_resource_permissions"
+    GET_RESOURCES_WITH_PERMISSION = "get_resources_with_permission"
     # OAuth2 Endpoints
     AUTHORIZE_CLIENT = "authorize_client"
     REQUEST_TOKEN = "request_token"

--- a/backend/src/contaxy/schema/shared.py
+++ b/backend/src/contaxy/schema/shared.py
@@ -42,7 +42,7 @@ class CoreOperations(str, Enum):
     CREATE_TOKEN = "create_token"
     LOGOUT_USER_SESSION = "logout_user_session"
     LOGIN_USER_SESSION = "login_user_session"
-    GET_RESOURCE_PERMISSIONS = "get_resource_permissions"
+    LIST_RESOURCE_PERMISSIONS = "list_resource_permissions"
     SET_RESOURCE_PERMISSIONS = "set_resource_permissions"
     DELETE_RESOURCE_PERMISSIONS = "delete_resource_permissions"
     GET_RESOURCES_WITH_PERMISSION = "get_resources_with_permission"


### PR DESCRIPTION
At the moment, the contaxy API does not allow to directly view and modify the users permissions. It's only indirectly possible (e.g. adding a user to a project adds the permission for that project).
For extensions or admin users it would be helpful, to have direct access to the user's permissions. Therefore, API endpoints for the following actions should be added:

list permissions of a user
add a new permission to a user
remove a permission from a user
list all users that have a certain permission