### PR TITLE
Refactor deployment manager to use DB as source for all service metadata.

### DIFF
--- a/backend/src/contaxy/managers/components.py
+++ b/backend/src/contaxy/managers/components.py
@@ -6,7 +6,7 @@ from pydantic.networks import PostgresDsn
 
 from contaxy import config
 from contaxy.managers.auth import AuthManager
-from contaxy.managers.deployment.manager import DeploymentManagerWithDB
+from contaxy.managers.deployment.manager import DeploymentManager
 from contaxy.managers.extension import ExtensionManager
 from contaxy.managers.project import ProjectManager
 from contaxy.managers.seed import SeedManager
@@ -223,28 +223,23 @@ class ComponentManager(ComponentOperations):
                 self.global_state.settings.DEPLOYMENT_MANAGER
                 == config.DeploymentManager.DOCKER
             ):
-                from contaxy.managers.deployment.docker import DockerDeploymentManager
+                from contaxy.managers.deployment.docker import DockerDeploymentPlatform
 
-                self._deployment_manager = DockerDeploymentManager(self)
                 # Add DB persistence to docker deployment manager
-                self._deployment_manager = DeploymentManagerWithDB(
-                    self._deployment_manager, self
+                self._deployment_manager = DeploymentManager(
+                    DockerDeploymentPlatform(), self
                 )
             elif (
                 self.global_state.settings.DEPLOYMENT_MANAGER
                 == config.DeploymentManager.KUBERNETES
             ):
                 from contaxy.managers.deployment.kubernetes import (
-                    KubernetesDeploymentManager,
+                    KubernetesDeploymentPlatform,
                 )
 
-                self._deployment_manager = KubernetesDeploymentManager(
-                    self,
-                    self.global_state.settings.KUBERNETES_NAMESPACE,
-                )
                 # Add DB persistence to kubernetes deployment manager
-                self._deployment_manager = DeploymentManagerWithDB(
-                    self._deployment_manager, self
+                self._deployment_manager = DeploymentManager(
+                    KubernetesDeploymentPlatform(), self
                 )
 
         assert self._deployment_manager is not None

--- a/backend/src/contaxy/managers/deployment/docker.py
+++ b/backend/src/contaxy/managers/deployment/docker.py
@@ -17,44 +17,22 @@ from contaxy.managers.deployment.docker_utils import (
     reconnect_to_all_networks,
     wait_for_container,
 )
-from contaxy.managers.deployment.utils import Labels, split_image_name_and_tag
-from contaxy.operations import AuthOperations, DeploymentOperations, SystemOperations
-from contaxy.operations.components import ComponentOperations
 from contaxy.schema import Job, JobInput, ResourceAction, Service, ServiceInput
 from contaxy.schema.deployment import DeploymentType, ServiceUpdate
 from contaxy.schema.exceptions import ClientBaseError, ClientValueError
-from contaxy.utils.auth_utils import parse_userid_from_resource_name
 
 
-class DockerDeploymentManager(DeploymentOperations):
+class DockerDeploymentPlatform:
     _is_initialized = False
 
-    def __init__(
-        self,
-        component_manager: ComponentOperations,
-    ):
-        """Initializes the docker deployment manager.
-
-        Args:
-            component_manager: Instance of the component manager that grants access to the other managers.
-        """
-        self._global_state = component_manager.global_state
-        self._request_state = component_manager.request_state
-        self._component_manager = component_manager
+    def __init__(self) -> None:
+        """Initializes the docker deployment manager."""
 
         self.client = docker.from_env()
         # Reconnect the backend to all existing docker networks on startup
-        if not DockerDeploymentManager._is_initialized:
+        if not DockerDeploymentPlatform._is_initialized:
             reconnect_to_all_networks(self.client)
-            DockerDeploymentManager._is_initialized = True
-
-    @property
-    def _system_manager(self) -> SystemOperations:
-        return self._component_manager.get_system_manager()
-
-    @property
-    def _auth_manager(self) -> AuthOperations:
-        return self._component_manager.get_auth_manager()
+            DockerDeploymentPlatform._is_initialized = True
 
     def list_services(
         self,
@@ -77,24 +55,14 @@ class DockerDeploymentManager(DeploymentOperations):
     def deploy_service(
         self,
         project_id: str,
-        service: ServiceInput,
+        service: Service,
         action_id: Optional[str] = None,
-        deployment_type: Literal[
-            DeploymentType.SERVICE, DeploymentType.EXTENSION
-        ] = DeploymentType.SERVICE,
         wait: bool = False,
     ) -> Service:
-        image_name, image_tag = split_image_name_and_tag(service.container_image)
-        self._system_manager.check_allowed_image(image_name, image_tag)
         container_config = create_container_config(
-            service=service,
+            deployment=service,
             project_id=project_id,
-            auth_manager=self._auth_manager,
-            user_id=parse_userid_from_resource_name(
-                self._request_state.authorized_subject
-            ),
         )
-        container_config["labels"][Labels.DEPLOYMENT_TYPE.value] = deployment_type.value
         handle_network(client=self.client, project_id=project_id)
 
         try:
@@ -168,23 +136,14 @@ class DockerDeploymentManager(DeploymentOperations):
     def deploy_job(
         self,
         project_id: str,
-        job: JobInput,
+        job: Job,
         action_id: Optional[str] = None,
         wait: bool = False,
     ) -> Job:
-        image_name, image_tag = split_image_name_and_tag(job.container_image)
-        self._system_manager.check_allowed_image(image_name, image_tag)
         container_config = create_container_config(
-            service=job,
+            deployment=job,
             project_id=project_id,
-            auth_manager=self._auth_manager,
-            user_id=parse_userid_from_resource_name(
-                self._request_state.authorized_subject
-            ),
         )
-        container_config["labels"][
-            Labels.DEPLOYMENT_TYPE.value
-        ] = DeploymentType.JOB.value
         handle_network(client=self.client, project_id=project_id)
 
         try:

--- a/backend/src/contaxy/managers/deployment/kube_utils.py
+++ b/backend/src/contaxy/managers/deployment/kube_utils.py
@@ -35,23 +35,20 @@ from contaxy.config import settings
 from contaxy.managers.deployment.utils import (
     _MIN_MEMORY_DEFAULT_MB,
     Labels,
-    clean_labels,
-    get_default_environment_variables,
     get_label_string,
     get_project_selection_labels,
-    get_template_mapping,
-    map_endpoints_to_endpoints_label,
     map_labels,
-    replace_templates,
+    map_list_to_string,
 )
-from contaxy.operations import AuthOperations
-from contaxy.schema import Job, JobInput, Service, ServiceInput
+from contaxy.schema import Job, Service
 from contaxy.schema.deployment import (
+    Deployment,
     DeploymentCompute,
     DeploymentStatus,
     DeploymentType,
 )
 from contaxy.schema.exceptions import ResourceNotFoundError, ServerBaseError
+from contaxy.utils.utils import remove_none_values_from_dict
 
 
 def get_label_selector(label_pairs: List[Tuple[str, str]]) -> str:
@@ -102,7 +99,7 @@ def get_pod(
         [
             (Labels.NAMESPACE.value, settings.SYSTEM_NAMESPACE),
             (Labels.PROJECT_NAME.value, project_id),
-            (Labels.DEPLOYMENT_NAME.value, service_id),
+            (Labels.DEPLOYMENT_ID.value, service_id),
         ]
     )
 
@@ -157,7 +154,7 @@ def create_service(
 
 
 def build_kube_service_config(
-    service_id: str, service: ServiceInput, project_id: str, kube_namespace: str
+    service: Service, project_id: str, kube_namespace: str
 ) -> V1Service:
     # TODO: set the endpoints as annotations
     service_ports: Dict[str, V1ServicePort] = {}
@@ -179,21 +176,21 @@ def build_kube_service_config(
     return V1Service(
         metadata=V1ObjectMeta(
             namespace=kube_namespace,
-            name=service_id,
+            name=service.id,
             labels={
                 # Labels.DISPLAY_NAME.value: service.display_name,# display_name cannot be a label since whitespaces are not allowed in label values. Kubernetes validation regex: (([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
                 Labels.NAMESPACE.value: settings.SYSTEM_NAMESPACE,
                 Labels.PROJECT_NAME.value: project_id,
-                Labels.DEPLOYMENT_NAME.value: service_id,
-                Labels.DEPLOYMENT_TYPE.value: DeploymentType.SERVICE.value,
+                Labels.DEPLOYMENT_ID.value: service.id,
+                Labels.DEPLOYMENT_TYPE.value: service.deployment_type,
             },  # service.labels
         ),
         spec=V1ServiceSpec(
             selector={
-                Labels.DEPLOYMENT_NAME.value: service_id,
+                Labels.DEPLOYMENT_ID.value: service.id,
                 Labels.PROJECT_NAME.value: project_id,
                 Labels.NAMESPACE.value: settings.SYSTEM_NAMESPACE,
-                Labels.DEPLOYMENT_TYPE.value: DeploymentType.SERVICE.value,
+                Labels.DEPLOYMENT_TYPE.value: service.deployment_type,
             },
             # ports must be set and it must contain at least one port
             ports=list(service_ports.values())
@@ -205,14 +202,10 @@ def build_kube_service_config(
 
 
 def build_pod_template_spec(
-    project_id: str,
-    service_id: str,
-    service: Union[ServiceInput, JobInput],
+    deployment: Deployment,
     metadata: V1ObjectMeta,
-    auth_manager: AuthOperations,
-    user_id: Optional[str] = None,
 ) -> V1PodTemplateSpec:
-    compute_resources = service.compute or DeploymentCompute()
+    compute_resources = deployment.compute
     # TODO: check default values and store them globally probably!
     min_cpus = compute_resources.min_cpus or 0
     max_cpus = compute_resources.max_cpus or 1
@@ -233,57 +226,38 @@ def build_pod_template_spec(
         },
     )
 
-    environment = service.parameters or {}
-    # The user MUST not be able to manually set (which) GPUs to use
-    if "NVIDIA_VISIBLE_DEVICES" in environment:
-        del environment["NVIDIA_VISIBLE_DEVICES"]
-    environment = {
-        **environment,
-        **get_default_environment_variables(
-            project_id=project_id,
-            deployment_id=service_id,
-            auth_manager=auth_manager,
-            endpoints=service.endpoints,
-            compute_resources=compute_resources,
-        ),
-    }
-    environment = replace_templates(
-        environment,
-        get_template_mapping(
-            project_id=project_id, user_id=user_id, environment=environment
-        ),
-    )
-
     # the name is used by Kubernetes to match the container-volume and the pod-volume section
-    mount_name = f"mount-{service_id}"
-    container = V1Container(
-        name=service_id,
-        image=service.container_image,
-        image_pull_policy="IfNotPresent",
-        resources=resource_requirements,
-        command=service.command,
-        args=service.args,
-        env=[V1EnvVar(name=name, value=value) for name, value in environment.items()],
-        volume_mounts=[
+    mount_name = f"mount-{deployment.id}"
+    volume_mounts, volumes = None, None
+    if compute_resources.volume_path:
+        volume_mounts = [
             V1VolumeMount(
                 name=mount_name, mount_path=str(compute_resources.volume_path)
             )
         ]
-        if compute_resources.volume_path
-        else None,
-    )
-
-    pod_spec = V1PodSpec(
-        volumes=[
+        volumes = [
             V1Volume(
                 name=mount_name,
                 persistent_volume_claim=V1PersistentVolumeClaimVolumeSource(
-                    claim_name=service_id
+                    claim_name=deployment.id
                 ),
             )
         ]
-        if compute_resources.volume_path
-        else None,
+    container = V1Container(
+        name=deployment.id,
+        image=deployment.container_image,
+        image_pull_policy="IfNotPresent",
+        resources=resource_requirements,
+        command=deployment.command,
+        args=deployment.args,
+        env=[
+            V1EnvVar(name=name, value=value)
+            for name, value in deployment.parameters.items()
+        ],
+        volume_mounts=volume_mounts,
+    )
+    pod_spec = V1PodSpec(
+        volumes=volumes,
         containers=[container],
     )
 
@@ -293,60 +267,44 @@ def build_pod_template_spec(
 def build_deployment_metadata(
     kube_namespace: str,
     project_id: str,
-    deployment_id: str,
-    display_name: Optional[str],
-    labels: Optional[Dict[str, str]],
-    compute_resources: Optional[DeploymentCompute],
-    endpoints: Optional[List[str]],
-    deployment_type: DeploymentType = DeploymentType.SERVICE,
-    user_id: Optional[str] = None,
+    deployment: Deployment,
 ) -> V1ObjectMeta:
-    display_name = display_name or ""
-    _compute_resources = compute_resources or DeploymentCompute()
-    min_lifetime = _compute_resources.min_lifetime or 0
-    cleaned_labels = clean_labels(labels)
-
     return V1ObjectMeta(
         namespace=kube_namespace,
-        name=deployment_id,
+        name=deployment.id,
         labels={
             Labels.NAMESPACE.value: settings.SYSTEM_NAMESPACE,
             Labels.PROJECT_NAME.value: project_id,
-            Labels.DEPLOYMENT_NAME.value: deployment_id,
-            Labels.DEPLOYMENT_TYPE.value: deployment_type.value,
+            Labels.DEPLOYMENT_ID.value: deployment.id,
+            Labels.DEPLOYMENT_TYPE.value: deployment.deployment_type.value,
         },
         annotations={
-            Labels.DISPLAY_NAME.value: display_name,
-            Labels.MIN_LIFETIME.value: str(min_lifetime),
-            Labels.ENDPOINTS.value: map_endpoints_to_endpoints_label(endpoints),
-            Labels.CREATED_BY.value: user_id,
-            **cleaned_labels,
+            **deployment.metadata,
+            Labels.DISPLAY_NAME.value: deployment.display_name,
+            Labels.DEPLOYMENT_TYPE.value: deployment.deployment_type.value,
+            Labels.DESCRIPTION.value: deployment.description,
+            Labels.ENDPOINTS.value: map_list_to_string(deployment.endpoints),
+            Labels.REQUIREMENTS.value: map_list_to_string(deployment.requirements),
+            Labels.ICON.value: deployment.icon,
+            Labels.MIN_LIFETIME.value: str(deployment.compute.min_lifetime),
+            Labels.CREATED_BY.value: deployment.created_by,
+            Labels.VOLUME_PATH.value: deployment.compute.volume_path,
         },
     )
 
 
 def build_kube_deployment_config(
-    service_id: str,
-    service: ServiceInput,
+    service: Service,
     project_id: str,
     kube_namespace: str,
-    auth_manager: AuthOperations,
-    user_id: Optional[str] = None,
 ) -> Tuple[V1Deployment, Union[V1PersistentVolumeClaim, None]]:
-    # ---
-    compute_resources = service.compute or DeploymentCompute()
+    compute_resources = service.compute
 
     metadata = build_deployment_metadata(
         kube_namespace=kube_namespace,
         project_id=project_id,
-        deployment_id=service_id,
-        display_name=service.display_name,
-        labels=service.metadata,
-        compute_resources=compute_resources,
-        endpoints=service.endpoints,
+        deployment=service,
     )
-
-    # ---
 
     pvc = None
     # add mount - handle PVC; ignore Secret, Bind and NFS for now
@@ -373,7 +331,6 @@ def build_kube_deployment_config(
 
     # --
 
-    # TODO: set `.spec.minReadySeconds` option (see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds)
     deployment = V1Deployment(
         metadata=metadata,
         spec=V1DeploymentSpec(
@@ -383,20 +340,18 @@ def build_kube_deployment_config(
             else 1,
             selector=V1LabelSelector(
                 match_labels={
-                    Labels.DEPLOYMENT_NAME.value: service_id,
+                    Labels.DEPLOYMENT_ID.value: service.id,
                     Labels.PROJECT_NAME.value: project_id,
                     Labels.NAMESPACE.value: settings.SYSTEM_NAMESPACE,
-                    Labels.DEPLOYMENT_TYPE.value: DeploymentType.SERVICE.value,
+                    Labels.DEPLOYMENT_TYPE.value: service.deployment_type.value,
                 }
             ),
             template=build_pod_template_spec(
-                project_id=project_id,
-                service_id=service_id,
-                service=service,
+                deployment=service,
                 metadata=metadata,
-                auth_manager=auth_manager,
-                user_id=user_id,
             ),
+            # TODO: Make min ready seconds configurable? (see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds)
+            min_ready_seconds=5,
         ),
     )
 
@@ -548,8 +503,8 @@ def map_deployment(deployment: Union[V1Deployment, V1Job]) -> Dict[str, Any]:
             resources.limits["memory"].strip(string.ascii_letters)
         ),  # / 1000 / 1000,
         max_gpus=None,  # TODO: fill with sensible information - where to get it from?
-        min_lifetime=mapped_labels.min_lifetime,
-        volume_Path=mapped_labels.volume_path,
+        min_lifetime=mapped_labels.min_lifetime or 0,
+        volume_path=mapped_labels.volume_path,
         # TODO: add max_volume_size, max_replicas
     )
 
@@ -615,10 +570,12 @@ def map_kube_service(
     deployment: V1Deployment,
 ) -> Service:
     transformed_deployment = map_deployment(deployment=deployment)
+    transformed_deployment = remove_none_values_from_dict(transformed_deployment)
     return Service(**transformed_deployment)
 
 
 def map_kube_job(job: V1Job) -> Job:
     transformed_job = map_deployment(deployment=job)
+    transformed_job = remove_none_values_from_dict(transformed_job)
     # TODO: add status SUCCESSFUL or FAILED
     return Job(**transformed_job)

--- a/backend/src/contaxy/managers/extension.py
+++ b/backend/src/contaxy/managers/extension.py
@@ -55,7 +55,7 @@ def map_service_to_extension(service: Service, user_id: str) -> Extension:
 
     if service.metadata:
         project_id = service.metadata[Labels.PROJECT_NAME.value]
-        deployment_id = service.metadata[Labels.DEPLOYMENT_NAME.value]
+        deployment_id = service.id
         endpoint_prefix = f"{config.settings.CONTAXY_BASE_URL}/projects/{project_id}/services/{deployment_id}/access/"
 
         if METADATA_CAPABILITIES in service.metadata:
@@ -217,7 +217,7 @@ class ExtensionManager(ExtensionOperations):
 
         service = self._service_manager.deploy_service(
             project_id=project_id,
-            service=service_input,
+            service_input=service_input,
             deployment_type=DeploymentType.EXTENSION,
         )
         return map_service_to_extension(

--- a/backend/src/contaxy/operations/deployment.py
+++ b/backend/src/contaxy/operations/deployment.py
@@ -30,7 +30,7 @@ class ServiceOperations(ABC):
     def deploy_service(
         self,
         project_id: str,
-        service: ServiceInput,
+        service_input: ServiceInput,
         action_id: Optional[str] = None,
         deployment_type: Literal[
             DeploymentType.SERVICE, DeploymentType.EXTENSION
@@ -48,7 +48,7 @@ class ServiceOperations(ABC):
 
         Args:
             project_id (str): The id of the project that the service should be assigned to.
-            service (ServiceInput): The service input which can be used to configure the deployed service.
+            service_input (ServiceInput): The service input which can be used to configure the deployed service.
             action_id (Optional[str], optional): The ID of the selected action. Defaults to `None`.
             deployment_type (One of [DeploymentType.SERVICE, DeploymentType.JOB]): The deployment type of either Service or Extension (which is a subtype of Service).
             wait (bool, optional): If set to True, the function will wait until the service was successfully created.
@@ -244,7 +244,7 @@ class JobOperations(ABC):
     def deploy_job(
         self,
         project_id: str,
-        job: JobInput,
+        job_input: JobInput,
         action_id: Optional[str] = None,
         wait: bool = False,
     ) -> Job:

--- a/backend/src/contaxy/schema/deployment.py
+++ b/backend/src/contaxy/schema/deployment.py
@@ -27,6 +27,7 @@ class DeploymentType(str, Enum):
     SERVICE = "service"
     JOB = "job"
     EXTENSION = "extension"
+    UNKNOWN = "unknown"
 
 
 class DeploymentStatus(str, Enum):
@@ -115,15 +116,15 @@ class DeploymentCompute(BaseModel):
         description="Maximum container size in Megabyte. The deployment will be killed if it grows above this limit.",
     )
     # TODO: min_replicas
-    max_replicas: Optional[int] = Field(
+    max_replicas: int = Field(
         1,
         example=2,
         ge=1,
         description="Maximum number of deployment instances. The system will make sure to optimize the deployment based on the available resources and requests. Use 1 if the deployment is not scalable.",
     )
     # TODO: use timedelta
-    min_lifetime: Optional[int] = Field(
-        None,
+    min_lifetime: int = Field(
+        0,
         example=86400,
         description="Minimum guaranteed lifetime in seconds. Once the lifetime is reached, the system is allowed to kill the deployment in case it requires additional resources.",
     )
@@ -136,13 +137,13 @@ class DeploymentBase(BaseModel):
         max_length=2000,
         description="The container image used for this deployment.",
     )
-    parameters: Optional[Dict[str, str]] = Field(
-        None,
+    parameters: Dict[str, str] = Field(
+        {},
         example={"TEST_PARAM": "param-value"},
-        description="Parmeters (enviornment variables) for this deployment.",
+        description="Parameters (environment variables) for this deployment.",
     )
-    compute: Optional[DeploymentCompute] = Field(
-        None,
+    compute: DeploymentCompute = Field(
+        DeploymentCompute(),
         description="Compute instructions and limitations for this deployment.",
     )
     command: Optional[List[str]] = Field(
@@ -153,12 +154,12 @@ class DeploymentBase(BaseModel):
         None,
         description="Arguments to the command/entrypoint. This overwrites the existing docker CMD.",
     )
-    requirements: Optional[List[str]] = Field(
-        None,
+    requirements: List[str] = Field(
+        [],
         description="Additional requirements for deployment.",
     )
-    endpoints: Optional[List[str]] = Field(
-        None,
+    endpoints: List[str] = Field(
+        [],
         example=["8080", "9001/webapp/ui", "9002b"],
         description="A list of HTTP endpoints that can be accessed. This should always have an internal port and can include additional instructions, such as the URL path.",
     )
@@ -191,12 +192,12 @@ class Deployment(Resource, DeploymentBase):
         None,
         description="The extension ID in case the deployment is deployed via an extension.",
     )
-    deployment_type: Optional[DeploymentType] = Field(
-        None,
+    deployment_type: DeploymentType = Field(
+        DeploymentType.UNKNOWN,
         description="The type of this deployment.",
     )
-    status: Optional[DeploymentStatus] = Field(
-        None,
+    status: DeploymentStatus = Field(
+        DeploymentStatus.UNKNOWN,
         example=DeploymentStatus.RUNNING,
         description="The status of this deployment.",
     )
@@ -238,7 +239,10 @@ class ServiceBase(BaseModel):
 
 
 class ServiceInput(ServiceBase, DeploymentInput):
-    pass
+    is_stopped: bool = Field(
+        False,
+        description="If set to true, the service will be created in the DB but not started. The service status will be 'stopped'.",
+    )
 
 
 class ServiceUpdate(ServiceInput):
@@ -250,13 +254,13 @@ class ServiceUpdate(ServiceInput):
         description="The container image used for this deployment.",
     )
     # Allow None for parameters and metadata values so they can be completely removed in an update request
-    parameters: Optional[Dict[str, Optional[str]]] = Field(  # type: ignore[assignment]
-        None,
+    parameters: Dict[str, Optional[str]] = Field(  # type: ignore[assignment]
+        {},
         example={"TEST_PARAM": "param-value"},
         description="Parmeters (enviornment variables) for this deployment.",
     )
-    metadata: Optional[Dict[str, Optional[str]]] = Field(  # type: ignore[assignment]
-        None,
+    metadata: Dict[str, Optional[str]] = Field(  # type: ignore[assignment]
+        {},
         example={"additional-metadata": "value"},
         description="A collection of arbitrary key-value pairs associated with this resource that does not need predefined structure. Enable third-party integrations to decorate objects with additional metadata for their own use.",
     )

--- a/backend/src/contaxy/schema/shared.py
+++ b/backend/src/contaxy/schema/shared.py
@@ -201,8 +201,8 @@ class ResourceInput(BaseModel):
         max_length=MAX_DISPLAY_NAME_LENGTH,
         description="A user-defined human-readable name of the resource. The name can be up to 128 characters long and can consist of any UTF-8 character.",
     )
-    description: Optional[str] = Field(
-        None,
+    description: str = Field(
+        "",
         max_length=MAX_DESCRIPTION_LENGTH,
         description="A user-defined short description about the resource. Can consist of any UTF-8 character.",
     )
@@ -210,12 +210,12 @@ class ResourceInput(BaseModel):
         None,
         description="Identifier or image URL used for displaying this resource.",
     )
-    metadata: Optional[Dict[str, str]] = Field(
-        None,
+    metadata: Dict[str, str] = Field(
+        {},
         example={"additional-metadata": "value"},
         description="A collection of arbitrary key-value pairs associated with this resource that does not need predefined structure. Enable third-party integrations to decorate objects with additional metadata for their own use.",
     )
-    disabled: Optional[bool] = Field(
+    disabled: bool = Field(
         False,
         description="Allows to disable a resource without requiring deletion. A disabled resource is not shown and not accessible.",
     )

--- a/backend/src/contaxy/utils/utils.py
+++ b/backend/src/contaxy/utils/utils.py
@@ -1,0 +1,5 @@
+from typing import Dict
+
+
+def remove_none_values_from_dict(dictionary: Dict) -> Dict:
+    return {k: v for k, v in dictionary.items() if v is not None}


### PR DESCRIPTION
This PR continues the refactoring of the deployment manager. 
All service metadata is now always stored in the DB. Additionally the data is still set as labels/annotations on the running containers/pods but these labels are no longer used to reconstruct the metadata when listing the services. 
Only the deployment status and internal id is not stored directly in the DB but is instead always queried during the deployment list/get request and is added dynamically to the response.

This also allows services to be created in a stopped status. That feature can for example be helpful to always create a default workspace for each user in ML Lab but don't have it running by default.