### PR TITLE
Fix service delation not deleting the named service volume, even if delete_volumes is set to true

### DIFF
--- a/backend/src/contaxy/managers/deployment/docker.py
+++ b/backend/src/contaxy/managers/deployment/docker.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Any, List, Literal, Optional
 
 import docker
+import docker.errors
 from loguru import logger
 
 from contaxy.managers.deployment.docker_utils import (
@@ -104,7 +105,9 @@ class DockerDeploymentPlatform:
         container = get_project_container(
             self.client, project_id=project_id, deployment_id=service_id
         )
-        delete_container(container=container, delete_volumes=delete_volumes)
+        delete_container(
+            client=self.client, container=container, delete_volumes=delete_volumes
+        )
 
     def delete_services(
         self,
@@ -182,7 +185,7 @@ class DockerDeploymentPlatform:
             deployment_id=job_id,
             deployment_type=DeploymentType.JOB,
         )
-        delete_container(container=container)
+        delete_container(client=self.client, container=container)
 
     def delete_jobs(
         self,


### PR DESCRIPTION
When deleting a service and requesting the deletion of its volumes via the delete_volumes parameter, the docker container remove API is called like this:
```container.remove(v=delete_volumes)```
From the docs for parameter `v=true`:
> Remove anonymous volumes associated with the container.

This means named volumes are not automatically deleted by this call!
This PR adds the missing logic for deleting all volumes associated with the service if delete_volumes is set to true.

Moreover, some missing imports for docker type definitions were added.
