### PR TITLE
Allow passing parameters to deployment actions

### DIFF
--- a/backend/src/contaxy/api/endpoints/deployment.py
+++ b/backend/src/contaxy/api/endpoints/deployment.py
@@ -28,7 +28,12 @@ from contaxy.schema.exceptions import (
 )
 from contaxy.schema.extension import EXTENSION_ID_PARAM
 from contaxy.schema.project import PROJECT_ID_PARAM
-from contaxy.schema.shared import OPEN_URL_REDIRECT, RESOURCE_ID_REGEX, CoreOperations
+from contaxy.schema.shared import (
+    OPEN_URL_REDIRECT,
+    RESOURCE_ID_REGEX,
+    CoreOperations,
+    ResourceActionExecution,
+)
 from contaxy.utils import auth_utils
 
 service_router = APIRouter(
@@ -379,7 +384,7 @@ def list_service_actions(
     )
 
 
-@service_router.get(
+@service_router.post(
     "/projects/{project_id}/services/{service_id}/actions/{action_id}",
     operation_id=ExtensibleOperations.EXECUTE_SERVICE_ACTION.value,
     # TODO: what is the response model? add additional status codes?
@@ -388,6 +393,7 @@ def list_service_actions(
     responses={**OPEN_URL_REDIRECT, **GET_RESOURCE_RESPONSES},
 )
 def execute_service_action(
+    action_execution: Optional[ResourceActionExecution] = None,
     project_id: str = PROJECT_ID_PARAM,
     service_id: str = SERVICE_ID_PARAM,
     action_id: str = Path(
@@ -413,7 +419,7 @@ def execute_service_action(
 
     action_id, extension_id = parse_composite_id(action_id)
     return component_manager.get_service_manager(extension_id).execute_service_action(
-        project_id, service_id, action_id
+        project_id, service_id, action_id, action_execution or ResourceActionExecution()
     )
 
 
@@ -715,7 +721,7 @@ def list_job_actions(
     )
 
 
-@job_router.get(
+@job_router.post(
     "/projects/{project_id}/jobs/{job_id}/actions/{action_id}",
     operation_id=ExtensibleOperations.EXECUTE_JOB_ACTION.value,
     # TODO: what is the response model? add additional status codes?
@@ -724,6 +730,7 @@ def list_job_actions(
     responses={**OPEN_URL_REDIRECT, **GET_RESOURCE_RESPONSES},
 )
 def execute_job_action(
+    action_execution: Optional[ResourceActionExecution] = None,
     project_id: str = PROJECT_ID_PARAM,
     job_id: str = JOB_ID_PARAM,
     action_id: str = Path(
@@ -749,7 +756,7 @@ def execute_job_action(
 
     action_id, extension_id = parse_composite_id(action_id)
     return component_manager.get_job_manager(extension_id).execute_job_action(
-        project_id, job_id, action_id
+        project_id, job_id, action_id, action_execution or ResourceActionExecution()
     )
 
 

--- a/backend/src/contaxy/clients/deployment.py
+++ b/backend/src/contaxy/clients/deployment.py
@@ -8,6 +8,7 @@ from contaxy.clients.shared import handle_errors
 from contaxy.operations.deployment import DeploymentOperations
 from contaxy.schema import Job, JobInput, ResourceAction, Service, ServiceInput
 from contaxy.schema.deployment import DeploymentType, ServiceUpdate
+from contaxy.schema.shared import ResourceActionExecution
 
 
 class DeploymentManagerClient(DeploymentOperations):
@@ -190,10 +191,12 @@ class DeploymentManagerClient(DeploymentOperations):
         project_id: str,
         service_id: str,
         action_id: str,
+        action_execution: ResourceActionExecution = ResourceActionExecution(),
         request_kwargs: Dict = {},
     ) -> None:
-        response = self.client.get(
+        response = self.client.post(
             f"/projects/{project_id}/services/{service_id}/actions/{action_id}",
+            json=action_execution.dict(exclude_unset=True),
             **request_kwargs,
         )
         handle_errors(response)
@@ -345,11 +348,13 @@ class DeploymentManagerClient(DeploymentOperations):
         project_id: str,
         job_id: str,
         action_id: str,
+        action_execution: ResourceActionExecution = ResourceActionExecution(),
         request_kwargs: Dict = {},
     ) -> None:
-        response = self.client.get(
+        response = self.client.post(
             f"/projects/{project_id}/jobs/{job_id}/actions/{action_id}",
             **request_kwargs,
+            json=action_execution.json(exclude_unset=True),
         )
         handle_errors(response)
         # TODO: Return response?

--- a/backend/src/contaxy/operations/deployment.py
+++ b/backend/src/contaxy/operations/deployment.py
@@ -4,6 +4,7 @@ from typing import Any, List, Literal, Optional
 
 from contaxy.schema import Job, JobInput, ResourceAction, Service, ServiceInput
 from contaxy.schema.deployment import DeploymentType, ServiceUpdate
+from contaxy.schema.shared import ResourceActionExecution
 
 
 class ServiceOperations(ABC):
@@ -218,6 +219,7 @@ class ServiceOperations(ABC):
         project_id: str,
         service_id: str,
         action_id: str,
+        action_execution: ResourceActionExecution = ResourceActionExecution(),
     ) -> Any:
         """Executes the selected service action.
 
@@ -228,6 +230,7 @@ class ServiceOperations(ABC):
             project_id (str): The project ID associated with the service.
             service_id (str): The ID of the service.
             action_id (str): The ID of the selected action.
+            action_execution (ResourceActionExecution): The action execution request which contains the action parameters
 
         Returns:
             `None` or a redirect response to another URL.
@@ -301,7 +304,13 @@ class JobOperations(ABC):
         pass
 
     @abstractmethod
-    def execute_job_action(self, project_id: str, job_id: str, action_id: str) -> Any:
+    def execute_job_action(
+        self,
+        project_id: str,
+        job_id: str,
+        action_id: str,
+        action_execution: ResourceActionExecution = ResourceActionExecution(),
+    ) -> Any:
         pass
 
 

--- a/backend/src/contaxy/schema/shared.py
+++ b/backend/src/contaxy/schema/shared.py
@@ -269,6 +269,14 @@ class ResourceAction(BaseModel):
     )
 
 
+class ResourceActionExecution(BaseModel):
+    parameters: Dict[str, str] = Field(
+        {},
+        description="Parameters that are passed to the resource action.",
+        example={"action-parameter": "parameter-value"},
+    )
+
+
 # TODO: use?
 # class BaseEntity(BaseModel):
 #     class Config:


### PR DESCRIPTION
This PR adds simple support for deployment actions that require parameters.
At the moment it is only used for the stop service action which can receive an optional `delete_volumes` parameter.

In the future this could be extended by listing the available parameters in the list deployment actions endpoint. Then a UI could show a dialog to the user, that allows to set parameters for the deployment action.