### PR TITLE
Stop services if they have not been accessed for a specified idle timeout

### DIFF
--- a/backend/src/contaxy/api/dependencies.py
+++ b/backend/src/contaxy/api/dependencies.py
@@ -54,5 +54,5 @@ def get_component_manager(request: Request) -> Generator[ComponentManager, None,
 
     This is used as FastAPI dependency and called for every request.
     """
-    with ComponentManager(request) as component_manager:
+    with ComponentManager.from_request(request) as component_manager:
         yield component_manager

--- a/backend/src/contaxy/config.py
+++ b/backend/src/contaxy/config.py
@@ -1,4 +1,5 @@
 import os
+from datetime import timedelta
 from enum import Enum
 from typing import List, Optional, Union
 
@@ -51,6 +52,7 @@ class Settings(BaseSettings):
     DEPLOYMENT_MANAGER: DeploymentManager = DeploymentManager.DOCKER
     KUBERNETES_NAMESPACE: Optional[str] = None
     HOST_DATA_ROOT_PATH: Optional[str] = None
+    SERVICE_IDLE_CHECK_INTERVAL: timedelta = timedelta(minutes=1)
 
     # Ensure host data root path ends with a slash
     @validator("HOST_DATA_ROOT_PATH")

--- a/backend/src/contaxy/managers/auth.py
+++ b/backend/src/contaxy/managers/auth.py
@@ -979,7 +979,7 @@ class AuthManager(AuthOperations):
             )
         except ResourceNotFoundError:
             logger.warning(
-                f"ResourceNotFoundError: No JSON document was found in the useres table with the given key: {user_id}."
+                f"ResourceNotFoundError: No JSON document was found in the users table with the given key: {user_id}."
             )
 
         try:
@@ -1023,7 +1023,9 @@ class AuthManager(AuthOperations):
             for login_mapping_doc in self._json_db_manager.list_json_documents(
                 config.SYSTEM_INTERNAL_PROJECT, self._LOGIN_ID_MAPPING_COLLECTION
             ):
-                mapped_user_id = LoginIdMapping.parse_raw(login_mapping_doc.json_value).user_id
+                mapped_user_id = LoginIdMapping.parse_raw(
+                    login_mapping_doc.json_value
+                ).user_id
                 if mapped_user_id == user_id:
                     self._json_db_manager.delete_json_document(
                         config.SYSTEM_INTERNAL_PROJECT,

--- a/backend/src/contaxy/schema/deployment.py
+++ b/backend/src/contaxy/schema/deployment.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import Enum
 from typing import Dict, List, Optional
 
@@ -235,6 +235,18 @@ class ServiceBase(BaseModel):
         None,
         example="8080/healthz",
         description="The endpoint instruction that can be used for checking the deployment health.",
+    )
+    idle_timeout: Optional[timedelta] = Field(
+        None,
+        description="Time after which the service is considered idling and will be stopped during the next idle check."
+        "If set to None, the workspace will never be considered idling."
+        "Can be specified as seconds or ISO 8601 time delta.",
+        example=None,
+    )
+    clear_volume_on_stop: bool = Field(
+        False,
+        description="If set to true, any volume attached to the service be deleted when the service is stopped."
+        "This means all persisted data will be cleared on service stop.",
     )
 
 

--- a/backend/src/contaxy/utils/fastapi_utils.py
+++ b/backend/src/contaxy/utils/fastapi_utils.py
@@ -1,10 +1,33 @@
 """Collection of utilities for FastAPI apps."""
 
+import asyncio
 import inspect
-from typing import Any, Type
+from datetime import timedelta
+from typing import Any, Callable, Type
 
 from fastapi import FastAPI, Form
+from loguru import logger
 from pydantic import BaseModel
+from starlette.concurrency import run_in_threadpool
+
+
+def schedule_call(func: Callable, interval: timedelta) -> None:
+    """Schedule a function to be called in regular intervals.
+
+    Args:
+        func (Callable): The function to be called regularly
+        interval (timedelta): The amount of time to wait between function calls
+    """
+
+    async def loop() -> None:
+        while True:
+            await asyncio.sleep(interval.seconds)
+            try:
+                await run_in_threadpool(func)
+            except Exception:
+                logger.exception(f"Error while executing scheduled function {func}!")
+
+    asyncio.create_task(loop())
 
 
 def as_form(cls: Type[BaseModel]) -> Any:


### PR DESCRIPTION
This PR introduces the idle_timeout setting for services. 
If a service is not accessed longer than specified in the idle timeout, it will be automatically stopped.
For computing the idle time, the last_access_time attribute is used. It is updated automatically when a new session token in generated for the service. That way, it is updated regular as long as the service is in use.

A background task is scheduled that will regularly check all services and stops the ones that are over their idle_timeout. Therefore, the services are not guaranteed to be stopped immediately when they pass their idle timeout. Instead, they will be stopped on the next run of the clean up task. The scheduled interval for this clean up task can be set via the `SERVICE_IDLE_CHECK_INTERVAL`.

Moreover, the flag `clear_volume_on_stop` was added to the service. If it is set to true, any attached volumes of the services will be deleted on stop. This allows the creation of services, that completely delete all their data if they idle for too long.