### PR TITLE
Make fields of file schema not optional where None values do not make sense.

### DIFF
--- a/backend/src/contaxy/managers/file/azure_blob.py
+++ b/backend/src/contaxy/managers/file/azure_blob.py
@@ -19,11 +19,7 @@ from contaxy.operations import FileOperations
 from contaxy.operations.components import ComponentOperations
 from contaxy.operations.json_db import JsonDocumentOperations
 from contaxy.schema import File, FileInput, ResourceAction
-from contaxy.schema.exceptions import (
-    ClientValueError,
-    ResourceNotFoundError,
-    ServerBaseError,
-)
+from contaxy.schema.exceptions import ResourceNotFoundError, ServerBaseError
 from contaxy.schema.file import FileStream
 from contaxy.schema.json_db import JsonDocument
 from contaxy.utils.file_utils import generate_file_id
@@ -53,7 +49,7 @@ def create_azure_blob_client(settings: Settings) -> BlobServiceClient:
             f"Could not connect to Azure object storage ({settings.AZURE_BLOB_CONNECTION_STRING})."
         )
         raise ServerBaseError(
-            "Could not connect to object storage. Check S3 endpoint configuration."
+            "Could not connect to object storage. Check Azure object storage endpoint configuration."
         )
     return client
 
@@ -206,11 +202,6 @@ class AzureBlobFileManager(FileOperations):
         logger.debug(
             f"update_file_metadata (`project_id`: {project_id}, `file_key`: {file_key}, `version`: {version})"
         )
-
-        if file.key != file_key:
-            raise ClientValueError(
-                f"File keys do not match (file_key: {file_key}, file.key {file.key})"
-            )
 
         azure_blob_client: BlobClient = self.client.get_blob_client(
             get_container_name(
@@ -486,7 +477,7 @@ class AzureBlobFileManager(FileOperations):
             "file_extension": file_extension,
             "file_size": blob.size,
             "etag": blob.etag,
-            "latest_version": blob.is_current_version,
+            "latest_version": blob.is_current_version or False,
             "version": blob.version_id,
             "content_type": blob.content_settings.content_type,
         }
@@ -533,7 +524,7 @@ class AzureBlobFileManager(FileOperations):
             file_versions.update({file.key: versions + [str(file.version)]})
 
         for file in file_data:
-            file.available_versions = file_versions.get(file.key)
+            file.available_versions = file_versions.get(file.key, [])
 
         return file_data, db_keys
 

--- a/backend/src/contaxy/managers/file/minio.py
+++ b/backend/src/contaxy/managers/file/minio.py
@@ -13,11 +13,7 @@ from contaxy.operations import FileOperations
 from contaxy.operations.components import ComponentOperations
 from contaxy.operations.json_db import JsonDocumentOperations
 from contaxy.schema import File, FileInput, ResourceAction
-from contaxy.schema.exceptions import (
-    ClientValueError,
-    ResourceNotFoundError,
-    ServerBaseError,
-)
+from contaxy.schema.exceptions import ResourceNotFoundError, ServerBaseError
 from contaxy.schema.file import FileStream
 from contaxy.schema.json_db import JsonDocument
 from contaxy.utils.file_utils import generate_file_id
@@ -173,11 +169,6 @@ class MinioFileManager(FileOperations):
         logger.debug(
             f"update_file_metadata (`project_id`: {project_id}, `file_key`: {file_key}, `version`: {version})"
         )
-
-        if file.key != file_key:
-            raise ClientValueError(
-                f"File keys do not match (file_key: {file_key}, file.key {file.key})"
-            )
 
         try:
             s3_object = self.client.stat_object(
@@ -456,7 +447,7 @@ class MinioFileManager(FileOperations):
             "file_extension": file_extension,
             "file_size": object.size,
             "etag": object.etag,
-            "latest_version": object.is_latest,
+            "latest_version": object.is_latest or False,
             "version": object.version_id,
         }
 
@@ -514,7 +505,7 @@ class MinioFileManager(FileOperations):
                 return [], []
 
         for file in file_data:
-            file.available_versions = file_versions.get(file.key)
+            file.available_versions = file_versions.get(file.key, [])
 
         return file_data, db_keys
 

--- a/backend/src/contaxy/schema/file.py
+++ b/backend/src/contaxy/schema/file.py
@@ -30,6 +30,18 @@ class FileStream(ABC):
 
 
 class FileBase(BaseModel):
+    pass
+    # TODO: v2
+    # content_encoding: Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field.
+    # content_disposition: Specifies presentational information for the object.
+    # content_language: The language the content is in.
+
+
+class FileInput(ResourceInput, FileBase):
+    pass
+
+
+class File(Resource, FileBase):
     key: str = Field(
         ...,
         example="datasets/customer-table.csv",
@@ -48,39 +60,28 @@ class FileBase(BaseModel):
         example="datasets/customer-table.csv",
         description="The ID (or access instruction) of the file on the file storage provider.",
     )
-    # TODO: v2
-    # content_encoding: Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field.
-    # content_disposition: Specifies presentational information for the object.
-    # content_language: The language the content is in.
-
-
-class FileInput(ResourceInput, FileBase):
-    pass
-
-
-class File(Resource, FileBase):
-    file_extension: Optional[str] = Field(
-        None,
+    file_extension: str = Field(
+        "",
         example="csv",
         description="The full file extension extracted from the key field. May contain multiple concatenated extensions, such as `tar.gz`.",
     )
-    file_size: Optional[ByteSize] = Field(
-        None,
+    file_size: ByteSize = Field(
+        0,
         example=1073741824,
         description="The file size in bytes.",
     )
-    version: Optional[str] = Field(
-        None,
+    version: str = Field(
+        ...,
         example="1614204512210009",
         description="Version tag of this file. The version order might not be inferable from the version tag.",
     )
-    available_versions: Optional[List[str]] = Field(
-        None,
+    available_versions: List[str] = Field(
+        [],
         example=["1614204512210009", "23424512210009", "6144204512210009"],
         description="All version tags available for the given file.",
     )
-    latest_version: Optional[bool] = Field(
-        None,
+    latest_version: bool = Field(
+        ...,
         example=True,
         description="Indicates if this is the latest available version of the file.",
     )

--- a/backend/tests/test_file_operations.py
+++ b/backend/tests/test_file_operations.py
@@ -164,6 +164,7 @@ class FileOperationsTests(ABC):
         )
         assert version_1.md5_hash == file_stream.hash
         assert version_1.key == file_key
+        assert version_1.latest_version is True
 
         # Test - File exists
         file_stream = self.seeder.create_file_stream()
@@ -172,6 +173,12 @@ class FileOperationsTests(ABC):
         )
         assert version_1.version != version_2.version
         assert version_2.md5_hash == file_stream.hash
+        assert version_2.latest_version is True
+
+        version_1 = self.file_manager.get_file_metadata(
+            self.project_id, file_key, version=version_1.version
+        )
+        assert version_1.latest_version is False
 
     def test_download_file(self) -> None:
         file_key = "test-download-file.bin"


### PR DESCRIPTION
Some fields in the schema for the contaxy file management were marked as optional. That makes it hard to work with, as a check for None need to be done before usage of the field.
For fields that should always have a value, the Optional type has been removed.
