### PR TITLE
Remove user's API token from DB after logout

### DIFF
--- a/backend/src/contaxy/api/endpoints/auth.py
+++ b/backend/src/contaxy/api/endpoints/auth.py
@@ -136,12 +136,13 @@ def login_user_session(
 )
 def logout_user_session(
     component_manager: ComponentManager = Depends(get_component_manager),
+    token: str = Depends(get_api_token),
 ) -> Any:
     """Removes all session token cookies and redirects to the login page.
 
     When making requests to the this endpoint, the browser should be redirected to this endpoint.
     """
-    # RedirectResponse("./login", status_code=307)
+    component_manager.verify_access(token)
     return component_manager.get_auth_manager().logout_session()
 
 

--- a/backend/src/contaxy/managers/auth.py
+++ b/backend/src/contaxy/managers/auth.py
@@ -137,6 +137,16 @@ class AuthManager(AuthOperations):
         pass
 
     def logout_session(self) -> RedirectResponse:
+        # Remove login token of user from DB
+        if (
+            self._request_state.authorized_access
+            and self._request_state.authorized_access.access_token
+        ):
+            self._json_db_manager.delete_json_document(
+                config.SYSTEM_INTERNAL_PROJECT,
+                self._API_TOKEN_COLLECTION,
+                self._request_state.authorized_access.access_token.token,
+            )
         # TODO: where to redirect to
         rr = RedirectResponse("/welcome", status_code=307)
         rr.delete_cookie(config.API_TOKEN_NAME)


### PR DESCRIPTION
When the user logs in, a new API token in generated and stored as a cookie in the user's browser.
Once the user clicks the log out button this token is removed from the browser's cookies but at the moment it will remain in the backend data base. Because of that, a lot of unused tokens fill up the data base.
This PR add logic to the logout endpoint that removes the token which was used to perform the logout.