### PR TITLE
Improve user and project token endpoints to return same token if it was already generated.

### DIFF
--- a/backend/src/contaxy/managers/file/azure_blob.py
+++ b/backend/src/contaxy/managers/file/azure_blob.py
@@ -276,7 +276,9 @@ class AzureBlobFileManager(FileOperations):
         try:
             blob_client = container_client.upload_blob(
                 file_key,
-                file_stream,
+                # Filestream class has read method which is the only requirement for upload blob
+                # Therefore the type mismatch can be ignored
+                file_stream,  # type: ignore
                 content_settings=ContentSettings(
                     content_type=content_type,
                 ),

--- a/backend/src/contaxy/schema/file.py
+++ b/backend/src/contaxy/schema/file.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from typing import List, Optional
 
 from fastapi import Path
@@ -20,7 +20,8 @@ FILE_KEY_PARAM = Path(
 
 
 class FileStream(ABC):
-    @abstractproperty
+    @property
+    @abstractmethod
     def hash(self) -> str:
         pass
 


### PR DESCRIPTION
So far the project and user token endpoint generate a new token every time. That would cause quite a lot of tokens to be generated over time. 
This PR adds code to check if a user/project token was already created and return that instead of generating a new one.