### PR TITLE
Track last activity of users

### DIFF
--- a/backend/src/contaxy/api/endpoints/auth.py
+++ b/backend/src/contaxy/api/endpoints/auth.py
@@ -336,6 +336,12 @@ def create_token(
         resource_name, access_level = auth_utils.parse_permission(scope)
         component_manager.verify_access(token, resource_name, access_level)
 
+    # Update user last activity time when new token is requested. This updates the time on logon and also on session token refresh.
+    user_id = id_utils.extract_user_id_from_resource_name(
+        authorized_access.authorized_subject
+    )
+    component_manager.get_auth_manager().update_user_last_activity_time(user_id=user_id)
+
     return component_manager.get_auth_manager().create_token(
         token_subject=authorized_access.authorized_subject,
         scopes=scopes,

--- a/backend/src/contaxy/api/endpoints/user.py
+++ b/backend/src/contaxy/api/endpoints/user.py
@@ -116,12 +116,13 @@ def get_my_user(
     component_manager.verify_access(
         token, authorized_access.authorized_subject, AccessLevel.READ
     )
-
-    return component_manager.get_auth_manager().get_user(
-        id_utils.extract_user_id_from_resource_name(
-            authorized_access.authorized_subject
-        )
+    user_id = id_utils.extract_user_id_from_resource_name(
+        authorized_access.authorized_subject
     )
+    # Update the last activity time of the user only in this endpoint as it is always called when the UI is loaded
+    component_manager.get_auth_manager().update_user_last_activity_time(user_id)
+
+    return component_manager.get_auth_manager().get_user(user_id)
 
 
 @router.get(

--- a/backend/src/contaxy/managers/auth.py
+++ b/backend/src/contaxy/managers/auth.py
@@ -1,3 +1,4 @@
+import json
 import threading
 import time
 from collections import deque
@@ -896,7 +897,6 @@ class AuthManager(AuthOperations):
         user = User(
             id=user_id,
             technical_user=technical_user,
-            created_at=datetime.now(timezone.utc),
             **user_input.dict(exclude_unset=True),
         )
 
@@ -967,6 +967,7 @@ class AuthManager(AuthOperations):
         Returns:
             User: The updated user information.
         """
+        # TODO: Ensure username and email don't exist and update login-id-mapping
         updated_document = self._json_db_manager.update_json_document(
             project_id=config.SYSTEM_INTERNAL_PROJECT,
             collection_id=self._USER_COLLECTION,
@@ -974,6 +975,16 @@ class AuthManager(AuthOperations):
             json_document=user_input.json(exclude_unset=True),
         )
         return User.parse_raw(updated_document.json_value)
+
+    def update_user_last_activity_time(self, user_id: str) -> None:
+        self._json_db_manager.update_json_document(
+            project_id=config.SYSTEM_INTERNAL_PROJECT,
+            collection_id=AuthManager._USER_COLLECTION,
+            key=user_id,
+            json_document=json.dumps(
+                {"last_activity": str(datetime.now(timezone.utc))}
+            ),
+        )
 
     def delete_user(self, user_id: str) -> None:
         """Deletes a user.

--- a/backend/src/contaxy/schema/auth.py
+++ b/backend/src/contaxy/schema/auth.py
@@ -1,7 +1,8 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
-from typing import List, Optional
+from typing import Dict, List, Optional
 
+import pydantic
 from fastapi import HTTPException, Path, status
 from pydantic import BaseModel, EmailStr, Field
 
@@ -20,6 +21,7 @@ class AccessLevel(str, Enum):
     READ = "read"  # Viewer, view: Allows admin access , Can only view existing resources. Permissions for read-only actions that do not affect state, such as viewing (but not modifying) existing resources or data.
     WRITE = "write"  # Editor, edit, Contributor : Allows read/write access , Can create and manage all types of resources but can’t grant access to others.  All viewer permissions, plus permissions for actions that modify state, such as changing existing resources.
     ADMIN = "admin"  # Owner : Allows read-only access. Has full access to all resources including the right to edit IAM, invite users, edit roles. All editor permissions and permissions for the following actions
+
     # UNKNOWN = "unknown"  # Deny?
 
     @classmethod
@@ -371,9 +373,8 @@ USER_ID_PARAM = Path(
     # TODO: add length restriction
 )
 
+
 # User Models
-
-
 class UserBase(BaseModel):
     username: Optional[str] = Field(
         None,
@@ -383,9 +384,9 @@ class UserBase(BaseModel):
     email: Optional[EmailStr] = Field(
         None, example="john.doe@example.com", description="User email address."
     )
-    disabled: Optional[bool] = Field(
+    disabled: bool = Field(
         False,
-        description="Indicates that user is disabled. Disabling a user will prevent any access to user-accesible resources.",
+        description="Indicates that user is disabled. Disabling a user will prevent any access to user-accessible resources.",
     )
 
 
@@ -405,15 +406,24 @@ class UserRegistration(UserInput):
 
 class User(UserBase):
     id: str = Field(
-        None,
+        ...,
         example="16fd2706-8baf-433b-82eb-8c7fada847da",
         description="Unique ID of the user.",
     )
-    technical_user: Optional[bool] = Field(
+    technical_user: bool = Field(
         False,
         description="Indicates if the user is a technical user created by the system.",
     )
-    created_at: Optional[datetime] = Field(
-        None,
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
         description="Timestamp of the user creation. Assigned by the server and read-only.",
     )
+    last_activity: datetime = Field(
+        None,  # If none the validator below will set last_activity to the create_at time
+        description="Last time the user accessed the system. Right now this is only updated when the user "
+        "calls the /users/me endpoint so that call should always be done when the user loads the UI.",
+    )
+
+    @pydantic.validator("last_activity", pre=True, always=True)
+    def default_last_activity(cls, v: datetime, *, values: Dict) -> datetime:
+        return v if v is not None else values["created_at"]


### PR DESCRIPTION
This PR adds tacking of the last activity time of users. 
At the moment, the last activity timestamp is only updated when the users/me endpoint is called (happens on every UI reload). And when a user requests a new session token (happens when the users interacts with a service (e.g. workspace manager)after the session token timeout)