### PR TITLE
Allow to pass metadata on file upload

### DIFF
--- a/.github/actions/build-environment/Dockerfile
+++ b/.github/actions/build-environment/Dockerfile
@@ -31,6 +31,8 @@ RUN \
   apt-get update \
   && apt-get install -y libpq-dev
 
+RUN pip install --no-cache-dir pipenv==2022.4.20
+
 COPY extended-entrypoint.sh /extended-entrypoint.sh
 
 RUN chmod +x /extended-entrypoint.sh

--- a/backend/src/contaxy/api/endpoints/file.py
+++ b/backend/src/contaxy/api/endpoints/file.py
@@ -115,8 +115,8 @@ def upload_file(
 
     metadata = dict()
     for key, value in request.headers.items():
-        if _FILE_METADATA_PREFIX in key:
-            metadata[key] = value
+        if key.startswith(_FILE_METADATA_PREFIX):
+            metadata[key[len(_FILE_METADATA_PREFIX):]] = value
 
     return component_manager.get_file_manager().upload_file(
         project_id, file_key, multipart_stream, metadata, content_type

--- a/backend/src/contaxy/managers/file/minio.py
+++ b/backend/src/contaxy/managers/file/minio.py
@@ -213,7 +213,8 @@ class MinioFileManager(FileOperations):
         project_id: str,
         file_key: str,
         file_stream: FileStream,
-        content_type: str = "application/octet-stream",
+        metadata: dict = None,
+        content_type: str = "application/octet-stream"
     ) -> File:
         """Upload a file.
 
@@ -250,6 +251,7 @@ class MinioFileManager(FileOperations):
                 -1,
                 content_type,
                 part_size=10 * 1024 * 1024,
+                metadata=metadata
             )
         except S3Error as err:
             raise ServerBaseError(
@@ -315,7 +317,7 @@ class MinioFileManager(FileOperations):
                     f"Invalid file {file_key} (version: {version}."
                 )
 
-        return response.stream()
+        return response.stream(), int(response.headers.get("Content-Length"))
 
     def delete_file(
         self,
@@ -449,6 +451,7 @@ class MinioFileManager(FileOperations):
             "etag": object.etag,
             "latest_version": object.is_latest or False,
             "version": object.version_id,
+            "metadata": object.metadata
         }
 
         # ! Minio seems to not set the content type, only when reading single object via stat_object, hence we persist it in the db

--- a/backend/src/contaxy/managers/file/minio.py
+++ b/backend/src/contaxy/managers/file/minio.py
@@ -250,8 +250,7 @@ class MinioFileManager(FileOperations):
                 file_stream,
                 -1,
                 content_type,
-                part_size=10 * 1024 * 1024,
-                metadata=metadata
+                part_size=10 * 1024 * 1024
             )
         except S3Error as err:
             raise ServerBaseError(
@@ -268,7 +267,7 @@ class MinioFileManager(FileOperations):
 
         # ? Get the data from the last version if existing?
         self._create_file_metadata_json_document(
-            project_id, file_key, result.version_id, file_hash
+            project_id, file_key, metadata, result.version_id, file_hash
         )
 
         # This is necessary in order to have the available versions metadata set
@@ -417,6 +416,7 @@ class MinioFileManager(FileOperations):
         self,
         project_id: str,
         file_key: str,
+        metadata: Dict[str, str],
         version: Optional[str] = None,
         md5_hash: Optional[str] = None,
     ) -> JsonDocument:
@@ -426,6 +426,7 @@ class MinioFileManager(FileOperations):
             version_id=version,
         )
         meta_file = self._map_s3_object_to_file_model(s3_object)
+        meta_file.metadata = metadata
         if md5_hash:
             meta_file.md5_hash = md5_hash
         metadata_json = self._map_file_obj_to_json_document(meta_file)
@@ -451,7 +452,6 @@ class MinioFileManager(FileOperations):
             "etag": object.etag,
             "latest_version": object.is_latest or False,
             "version": object.version_id,
-            "metadata": object.metadata
         }
 
         # ! Minio seems to not set the content type, only when reading single object via stat_object, hence we persist it in the db

--- a/backend/src/contaxy/operations/file.py
+++ b/backend/src/contaxy/operations/file.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from ast import Dict
 from typing import Any, Iterator, List, Optional
 
 from contaxy.schema import File, FileInput, FileStream, ResourceAction
@@ -82,6 +83,7 @@ class FileOperations(ABC):
         project_id: str,
         file_key: str,
         file_stream: FileStream,
+        metadata: dict = None,
         content_type: str = "application/octet-stream",
     ) -> File:
         """Upload a file.

--- a/backend/src/contaxy/operations/file.py
+++ b/backend/src/contaxy/operations/file.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
-from ast import Dict
-from typing import Any, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from contaxy.schema import File, FileInput, FileStream, ResourceAction
 
@@ -83,7 +82,7 @@ class FileOperations(ABC):
         project_id: str,
         file_key: str,
         file_stream: FileStream,
-        metadata: dict = None,
+        metadata: Optional[Dict[str, str]] = None,
         content_type: str = "application/octet-stream",
     ) -> File:
         """Upload a file.
@@ -92,6 +91,7 @@ class FileOperations(ABC):
             project_id (str): Project ID associated with the file.
             file_key (str): Key of the file.
             file_stream (FileStream): The actual file stream object.
+            metadata (Dict, optional): Additional key-value pairs of file meta data
             content_type (str, optional): The mime-type of the file. Defaults to "application/octet-stream".
 
         Raises:
@@ -108,7 +108,7 @@ class FileOperations(ABC):
         project_id: str,
         file_key: str,
         version: Optional[str] = None,
-    ) -> Iterator[bytes]:
+    ) -> Tuple[Iterator[bytes], int]:
         """Download a file.
 
         Either the latest version will be returned or the specified one.

--- a/backend/src/contaxy/schema/shared.py
+++ b/backend/src/contaxy/schema/shared.py
@@ -194,6 +194,7 @@ class ResourceMetadata(BaseModel):
     #    description="Timestamp when the resource should be deleted.",
     # )
 
+
 class ResourceInput(BaseModel):
     display_name: Optional[str] = Field(
         None,

--- a/backend/src/contaxy/schema/shared.py
+++ b/backend/src/contaxy/schema/shared.py
@@ -194,7 +194,6 @@ class ResourceMetadata(BaseModel):
     #    description="Timestamp when the resource should be deleted.",
     # )
 
-
 class ResourceInput(BaseModel):
     display_name: Optional[str] = Field(
         None,


### PR DESCRIPTION
With the commit, we worked the following changes:

1. Ability to store the metadata during file upload -  Now, instead of the corresponding minio S3 bucket storing the metadata, we store it as a Dict in its corresponding Postgre Database entry.
