### PR TITLE
Removing the 'name' attribute from schema

### DIFF
--- a/backend/src/contaxy/schema/shared.py
+++ b/backend/src/contaxy/schema/shared.py
@@ -155,16 +155,6 @@ class ResourceMetadata(BaseModel):
         example="ac9ldprwdi68oihk34jli3kdp",
         description="Resource ID. Identifies a resource in a given context and time, for example, in combination with its type. Used in API operations and/or configuration files.",
     )
-    name: Optional[str] = Field(
-        None,
-        example="resources/ac9ldprwdi68oihk34jli3kdp",
-        description="Resource Name. A relative URI-path that uniquely identifies a resource within the system. Assigned by the server and read-only.",
-    )
-    # kind: Optional[str] = Field(
-    #    None,
-    #    example="resources",
-    #    description="Resource Type (Schema). Identifies what kind of resource this is. Assigned by the server and read-only.",
-    # )
     created_at: Optional[datetime] = Field(
         None,
         description="Timestamp of the resource creation. Assigned by the server and read-only.",


### PR DESCRIPTION
In this PR, the 'name' attribute is being removed as currently, we are using the 'display_name' attribute to assign names for objects. Hence, accessing the 'name' attribute goes void. To avoid the unnecessary access and usage of the 'name' attribute, it is being removed from the schema.